### PR TITLE
Add missing rbac rules for routes & serviceaccounts

### DIFF
--- a/deploy/roles/role.yaml
+++ b/deploy/roles/role.yaml
@@ -14,6 +14,7 @@ rules:
   - events
   - configmaps
   - secrets
+  - serviceaccounts
   verbs:
   - '*'
 - apiGroups:
@@ -23,6 +24,12 @@ rules:
   - daemonsets
   - replicasets
   - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
   verbs:
   - '*'
 - apiGroups:


### PR DESCRIPTION
The operator was failing with rbac errors for getting/creating serviceaccounts & routes.
