### PR TITLE
Configurable image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-ORG=integr8ly
-NAMESPACE=application-monitoring
+ORG=integreatly
+NAMESPACE=middleware-monitoring
 PROJECT=grafana-operator
 REG=quay.io
 SHELL=/bin/bash

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"github.com/integr8ly/grafana-operator/pkg/controller/grafana"
 	"os"
 	"runtime"
 
@@ -29,6 +30,8 @@ func printVersion() {
 }
 
 func main() {
+	flagImage := flag.String("grafana-image", "", "Overrides the default Grafana image")
+	flagImageTag := flag.String("grafana-image-tag", "", "Overrides the default Grafana image tag")
 	flag.Parse()
 
 	// The logger instantiated here can be changed to any logger
@@ -38,6 +41,11 @@ func main() {
 	logf.SetLogger(logf.ZapLogger(false))
 
 	printVersion()
+
+	// Controller configuration
+	controllerConfig := grafana.GetControllerConfig()
+	controllerConfig.AddConfigItem(grafana.ConfigGrafanaImage, *flagImage)
+	controllerConfig.AddConfigItem(grafana.ConfigGrafanaImageTag, *flagImageTag)
 
 	namespace, err := k8sutil.GetWatchNamespace()
 	if err != nil {

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -22,6 +22,8 @@ import (
 )
 
 var log = logf.Log.WithName("cmd")
+var flagImage string
+var flagImageTag string
 
 func printVersion() {
 	log.Info(fmt.Sprintf("Go Version: %s", runtime.Version()))
@@ -29,11 +31,14 @@ func printVersion() {
 	log.Info(fmt.Sprintf("operator-sdk Version: %v", sdkVersion.Version))
 }
 
-func main() {
-	flagImage := flag.String("grafana-image", "", "Overrides the default Grafana image")
-	flagImageTag := flag.String("grafana-image-tag", "", "Overrides the default Grafana image tag")
-	flag.Parse()
+func init() {
+	flagset := flag.CommandLine
+	flagset.StringVar(&flagImage, "grafana-image", "", "Overrides the default Grafana image")
+	flagset.StringVar(&flagImageTag, "grafana-image-tag", "", "Overrides the default Grafana image tag")
+	flagset.Parse(os.Args[1:])
+}
 
+func main() {
 	// The logger instantiated here can be changed to any logger
 	// implementing the logr.Logger interface. This logger will
 	// be propagated through the whole operator, generating
@@ -44,8 +49,8 @@ func main() {
 
 	// Controller configuration
 	controllerConfig := grafana.GetControllerConfig()
-	controllerConfig.AddConfigItem(grafana.ConfigGrafanaImage, *flagImage)
-	controllerConfig.AddConfigItem(grafana.ConfigGrafanaImageTag, *flagImageTag)
+	controllerConfig.AddConfigItem(grafana.ConfigGrafanaImage, flagImage)
+	controllerConfig.AddConfigItem(grafana.ConfigGrafanaImageTag, flagImageTag)
 
 	namespace, err := k8sutil.GetWatchNamespace()
 	if err != nil {

--- a/pkg/controller/grafana/controller_config.go
+++ b/pkg/controller/grafana/controller_config.go
@@ -1,0 +1,42 @@
+package grafana
+
+import "sync"
+
+const (
+	ConfigGrafanaImage    = "grafana.image.url"
+	ConfigGrafanaImageTag = "grafana.image.tag"
+)
+
+type ControllerConfig struct {
+	Values map[string]string
+}
+
+var instance *ControllerConfig
+var once sync.Once
+
+func GetControllerConfig() *ControllerConfig {
+	once.Do(func() {
+		instance = &ControllerConfig{
+			Values: map[string]string{},
+		}
+	})
+	return instance
+}
+
+func (c *ControllerConfig) AddConfigItem(key, value string) {
+	if key != "" && value != "" {
+		c.Values[key] = value
+	}
+}
+
+func (c *ControllerConfig) GetConfigItem(key, defaultValue string) string {
+	if c.HasConfigItem(key) {
+		return c.Values[key]
+	}
+	return defaultValue
+}
+
+func (c *ControllerConfig) HasConfigItem(key string) bool {
+	_, ok := c.Values[key]
+	return ok
+}

--- a/pkg/controller/grafana/templateHelper.go
+++ b/pkg/controller/grafana/templateHelper.go
@@ -51,9 +51,11 @@ type GrafanaTemplateHelper struct {
 // templates properties. Some of them (like the hostname) are set
 // by the user in the custom resource
 func newTemplateHelper(cr *integreatly.Grafana) *GrafanaTemplateHelper {
+	controllerConfig := GetControllerConfig()
+
 	param := GrafanaParamaeters{
-		GrafanaImage:                    GrafanaImage,
-		GrafanaVersion:                  GrafanaVersion,
+		GrafanaImage:                    controllerConfig.GetConfigItem(ConfigGrafanaImage, GrafanaImage),
+		GrafanaVersion:                  controllerConfig.GetConfigItem(ConfigGrafanaImageTag, GrafanaVersion),
 		Namespace:                       cr.Namespace,
 		GrafanaConfigMapName:            GrafanaConfigMapName,
 		GrafanaProvidersConfigMapName:   GrafanaProvidersConfigMapName,


### PR DESCRIPTION
Make the Grafana Image and Tag configurable using command line args.

Verification:

1. Create an empty namespace using grafana
1. Run the operator locally using `operator-sdk up local --namespace=grafana --operator-flags "--grafana-image registry.redhat.io/openshift3/grafana --grafana-image-tag v3.11"`
1. Deploy a grafana instance to this namespace using `oc create -f deploy/examples/Grafana.yaml`
1. Wait until everything is deployed.
1. Inspect the Grafana deployment and make sure it is using the specified Red Hat image.
1. Delete the Grafana CR and restart the operator without the extra flags
1. Deploy another Grafana instance
1. Make sure that this time it is using the public community Grafana image.