### PR TITLE
allow extra containers in cr

### DIFF
--- a/pkg/apis/integreatly/v1alpha1/grafana_types.go
+++ b/pkg/apis/integreatly/v1alpha1/grafana_types.go
@@ -1,6 +1,7 @@
 package v1alpha1
 
 import (
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -13,6 +14,7 @@ type GrafanaSpec struct {
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
 	PrometheusUrl              string                `json:"prometheusUrl"`
 	DashboardNamespaceSelector *metav1.LabelSelector `json:"dashboardNamespaceSelector,omitempty"`
+	Containers                 []v1.Container        `json:"containers,omitempty"`
 }
 
 // GrafanaStatus defines the observed state of Grafana

--- a/pkg/apis/integreatly/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/integreatly/v1alpha1/zz_generated.deepcopy.go
@@ -5,6 +5,7 @@
 package v1alpha1
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
@@ -219,6 +220,13 @@ func (in *GrafanaSpec) DeepCopyInto(out *GrafanaSpec) {
 		in, out := &in.DashboardNamespaceSelector, &out.DashboardNamespaceSelector
 		*out = new(v1.LabelSelector)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.Containers != nil {
+		in, out := &in.Containers, &out.Containers
+		*out = make([]corev1.Container, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
 	}
 	return
 }

--- a/pkg/controller/grafana/grafana_controller.go
+++ b/pkg/controller/grafana/grafana_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"time"
@@ -203,20 +204,46 @@ func (r *ReconcileGrafana) CreateConfigFiles(cr *integreatly.Grafana) (reconcile
 
 func (r *ReconcileGrafana) InstallGrafana(cr *integreatly.Grafana) (reconcile.Result, error) {
 	log.Info("Phase: Install Grafana")
+	err := r.CreateDeployment(cr, GrafanaDeploymentName)
 
-	for _, resourceName := range []string{GrafanaDeploymentName} {
-		if err := r.CreateResource(cr, resourceName); err != nil {
-			log.Info(fmt.Sprintf("Error in InstallGrafana, resourceName=%s : err=%s", resourceName, err))
-			// Requeue so it can be attempted again
-			return reconcile.Result{Requeue: true}, err
-		}
+	if err != nil {
+		return reconcile.Result{Requeue: true}, err
 	}
 
 	log.Info("Grafana installation complete")
-	return reconcile.Result{Requeue: true}, r.UpdatePhase(cr, PhaseDone)
+	return reconcile.Result{}, r.UpdatePhase(cr, PhaseDone)
 }
 
-// Creates a generic kubernetes resource from a templates
+// Creates the deployment from the template and injects any specified extra containers before
+// submitting it
+func (r *ReconcileGrafana) CreateDeployment(cr *integreatly.Grafana, resourceName string) error {
+
+	resourceHelper := newResourceHelper(cr)
+	resource, err := resourceHelper.createResource(resourceName)
+
+	if err != nil {
+		return err
+	}
+
+	// Deploy the unmodified resource if no extra containers are specified
+	if len(cr.Spec.Containers) == 0 {
+		return r.DeployResource(cr, resource, resourceName)
+	}
+
+	// Otherwise append extra containers before submitting the resource
+	rawResource := newUnstructuredResourceMap(resource.(*unstructured.Unstructured))
+	containers := rawResource.access("spec").access("template").access("spec").get("containers").([]interface{})
+
+	for _, container := range cr.Spec.Containers {
+		containers = append(containers, container)
+		log.Info(fmt.Sprintf("adding extra container '%v' to '%v'", container.Name, GrafanaDeploymentName))
+	}
+
+	rawResource.access("spec").access("template").access("spec").set("containers", containers)
+	return r.DeployResource(cr, resource, resourceName)
+}
+
+// Creates a generic kubernetes resource from a template
 func (r *ReconcileGrafana) CreateResource(cr *integreatly.Grafana, resourceName string) error {
 	resourceHelper := newResourceHelper(cr)
 	resource, err := resourceHelper.createResource(resourceName)
@@ -225,12 +252,17 @@ func (r *ReconcileGrafana) CreateResource(cr *integreatly.Grafana, resourceName 
 		return err
 	}
 
+	return r.DeployResource(cr, resource, resourceName)
+}
+
+// Deploys a resource given by a runtime object
+func (r *ReconcileGrafana) DeployResource(cr *integreatly.Grafana, resource runtime.Object, resourceName string) error {
 	// Try to find the resource, it may already exist
 	selector := types.NamespacedName{
 		Namespace: cr.Namespace,
 		Name:      resourceName,
 	}
-	err = r.client.Get(context.TODO(), selector, resource)
+	err := r.client.Get(context.TODO(), selector, resource)
 
 	// The resource exists, do nothing
 	if err == nil {

--- a/pkg/controller/grafana/resourceHelper.go
+++ b/pkg/controller/grafana/resourceHelper.go
@@ -7,6 +7,37 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
+// An abstraction type that allows easier access to the contents of an
+// unstructured resource
+type UnstructuredResourceMap struct {
+	Values map[string]interface{}
+}
+
+// Go one level deeper in the unstructured resource map
+func (m UnstructuredResourceMap) access(key string) *UnstructuredResourceMap {
+	return &UnstructuredResourceMap{
+		Values: m.Values[key].(map[string]interface{}),
+	}
+}
+
+// Return value of the current level in the unstructured resource map
+func (m UnstructuredResourceMap) get(key string) interface{} {
+	return m.Values[key]
+}
+
+// Set value in an unstructured resource map
+func (m UnstructuredResourceMap) set(key string, value interface{}) {
+	m.Values[key] = value
+}
+
+// Create a new unstructured resource map
+func newUnstructuredResourceMap(unstructured *unstructured.Unstructured) *UnstructuredResourceMap {
+	return &UnstructuredResourceMap{
+		Values: unstructured.UnstructuredContent(),
+	}
+}
+
+// Helps with creating kubernetes resources from yaml templates
 type ResourceHelper struct {
 	templateHelper *GrafanaTemplateHelper
 	cr             *integreatly.Grafana

--- a/pkg/controller/grafana/resourceHelper_test.go
+++ b/pkg/controller/grafana/resourceHelper_test.go
@@ -1,0 +1,22 @@
+package grafana
+
+import (
+	"testing"
+)
+
+func TestCreateResource(t *testing.T) {
+	resourceHelper := newResourceHelper(&MockCR)
+	resourceHelper.templateHelper.TemplatePath = "../../../templates"
+
+	for _, template := range Templates {
+		obj, err := resourceHelper.createResource(template)
+
+		if err != nil {
+			t.Errorf("Error creating resource for templates %s", template)
+		}
+
+		if obj == nil {
+			t.Errorf("Invalid resource for templates %s", template)
+		}
+	}
+}

--- a/pkg/controller/grafana/testing_shared.go
+++ b/pkg/controller/grafana/testing_shared.go
@@ -1,6 +1,31 @@
 package grafana
 
-import "github.com/integr8ly/grafana-operator/pkg/apis/integreatly/v1alpha1"
+import (
+	"github.com/integr8ly/grafana-operator/pkg/apis/integreatly/v1alpha1"
+	v12 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var MockCR = v1alpha1.Grafana{
+	ObjectMeta: v1.ObjectMeta{
+		Name:      "test",
+		Namespace: "dummy",
+	},
+	Spec: v1alpha1.GrafanaSpec{
+		Containers:    []v12.Container{},
+		PrometheusUrl: "http://dummy",
+	},
+}
+
+var Templates = []string{
+	GrafanaDeploymentName,
+	GrafanaDashboardsConfigMapName,
+	GrafanaDatasourcesConfigMapName,
+	GrafanaRouteName,
+	GrafanaProvidersConfigMapName,
+	GrafanaServiceAccountName,
+	GrafanaServiceName,
+}
 
 var Mockplugina100 = v1alpha1.GrafanaPlugin{
 	Name:    "a",


### PR DESCRIPTION
Allow extra containers (like auth proxies) to be specified in the Grafana CR and add them to the deployment.

Verification steps:

1. Create a new empty namespace
1. Run the Operator from this branch against that namespace
1. Deploy Grafana using the following CR:

```yaml
apiVersion: integreatly.org/v1alpha1
kind: Grafana
metadata:
  name: example-grafana
spec:
  containers:
    - image: busybox
      command:
        - sleep
        - "3600"
      imagePullPolicy: IfNotPresent
      name: busybox
  prometheusUrl: "http://prometheus-application-monitoring:9090"
  dashboardNamespaceSelector:
    matchLabels:
      monitoring-key: middleware
```

Make sure that everything deploys fine and there is an extra `busybox` container in the Grafana deployment.

ping @laurafitzgerald