### PR TITLE
Compare resources

### DIFF
--- a/pkg/apis/integreatly/v1alpha1/grafanadatasource_types.go
+++ b/pkg/apis/integreatly/v1alpha1/grafanadatasource_types.go
@@ -20,7 +20,8 @@ type GrafanaDataSourceSpec struct {
 // GrafanaDataSourceStatus defines the observed state of GrafanaDataSource
 // +k8s:openapi-gen=true
 type GrafanaDataSourceStatus struct {
-	Phase int `json:"phase"`
+	Phase      int    `json:"phase"`
+	LastConfig string `json:"lastConfig"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 var (
-	Version = "1.1.0"
+	Version = "1.1.1"
 )


### PR DESCRIPTION
Check a data source for changes before updating and restarting Grafana. This needs to be done because on OpenShift it looks like a resource sometimes is reconciled even when there are no changes.

With this PR we store the md5 hash of the last configuration of the data source in it's status and check updates against that.