### PR TITLE
delete plugins when dashboard is deleted

### DIFF
--- a/pkg/controller/common/controller_config.go
+++ b/pkg/controller/common/controller_config.go
@@ -73,8 +73,10 @@ func (c *ControllerConfig) SetPluginsFor(dashboard *v1alpha1.GrafanaDashboard) {
 
 func (c *ControllerConfig) RemovePluginsFor(dashboard *v1alpha1.GrafanaDashboard) {
 	id := c.GetDashboardId(dashboard)
-	c.Plugins[id] = nil
-	c.AddConfigItem(ConfigGrafanaPluginsUpdated, time.Now())
+	if _, ok := c.Plugins[id]; ok {
+		delete(c.Plugins, id)
+		c.AddConfigItem(ConfigGrafanaPluginsUpdated, time.Now())
+	}
 }
 
 func (c *ControllerConfig) AddConfigItem(key string, value interface{}) {

--- a/pkg/controller/grafanadashboard/dashboard_controller.go
+++ b/pkg/controller/grafanadashboard/dashboard_controller.go
@@ -184,6 +184,7 @@ func (r *ReconcileGrafanaDashboard) deleteDashboard(d *i8ly.GrafanaDashboard) (r
 		log.Info(fmt.Sprintf("dashboard '%s/%s' deleted", d.Namespace, d.Spec.Name))
 	}
 
+	r.config.RemovePluginsFor(d)
 	return r.removeFinalizer(d)
 }
 


### PR DESCRIPTION
When a dashboard is deleted, it's plugins should be removed too unless they are also required by another dashboard.

Verification steps:

1. Run the operator and prepare two dashboards (you can use the one under `examples/dashboards`):
1. One dashboard that requires plugin A and B and the other that only requires A
1. Create the dashboards, make sure the operator installs both plugins
1. Remove the dashboard that only requires A
1. After the grafana restart, make sure that plugin B (and only plugin B) has been removed.