### PR TITLE
always import new data sources

### DIFF
--- a/pkg/controller/common/kubeHelper.go
+++ b/pkg/controller/common/kubeHelper.go
@@ -63,6 +63,25 @@ func (h KubeHelperImpl) UpdateDashboard(ns string, d *v1alpha1.GrafanaDashboard)
 	return true, nil
 }
 
+func (h KubeHelperImpl) IsKnownDataSource(ds *v1alpha1.GrafanaDataSource) (bool, error) {
+	configMap, err := h.getConfigMap(ds.Spec.Name, GrafanaDatasourcesConfigMapName)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	if configMap.Data == nil {
+		return false, nil
+	}
+
+	key := fmt.Sprintf("%s_%s", ds.Namespace, strings.ToLower(ds.Spec.Name))
+	_, found := configMap.Data[key]
+
+	return found, nil
+}
+
 func (h KubeHelperImpl) UpdateDataSources(name, namespace, ds string) (bool, error) {
 	configMap, err := h.getConfigMap(namespace, GrafanaDatasourcesConfigMapName)
 	if err != nil {


### PR DESCRIPTION
After a controller restart, a datasource was not reimported, even if gone from the configmap. The new policy is:

1. Check if a datasource is already in the configmap
1. If no, always import it
1. If yes, check for changes and only import if updated

Verification steps:

1. Deploy Grafana, create a data source and make sure it's imported
1. Uninstall Grafana by removing the CR, make sure the data source CR is still present
1. Restart the operator and reinstalll Grafana
1. Make sure the old datasource gets reimported