### PR TITLE
Intly 2704

### DIFF
--- a/deploy/cluster_roles/cluster_role.yaml
+++ b/deploy/cluster_roles/cluster_role.yaml
@@ -7,4 +7,5 @@ rules:
       - integreatly.org
     resources:
       - grafanadashboards
+      - grafanadashboards/finalizers
     verbs: ['get', 'list', 'update', 'watch']

--- a/deploy/roles/role.yaml
+++ b/deploy/roles/role.yaml
@@ -51,5 +51,8 @@ rules:
   - grafanas
   - grafanadashboards
   - grafanadatasources
+  - grafanas/finalizers
+  - grafanadashboards/finalizers
+  - grafanadatasources/finalizers
   verbs:
   - '*'

--- a/documentation/deploy_grafana.md
+++ b/documentation/deploy_grafana.md
@@ -12,6 +12,18 @@ To create a namespace named `grafana` run:
 $ kubectl create namespace grafana
 ```
 
+Create the operator roles:
+
+```sh
+$ kubectl create -f deploy/roles
+```
+
+If you want to scan for dashboards in other namespaces you also need the cluster roles:
+
+```sh
+$ kubectl create -f deploy/cluster_roles
+```
+
 To deploy the operator to that namespace you can use `deploy/operator.yaml`:
 
 ```sh
@@ -43,12 +55,14 @@ Create a custom resource of type `Grafana`, or use the one in `deploy/examples/G
 
 The resource accepts the following properties in it's `spec`:
 
-* *hostname*:  The host to be used for the [ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/). Optional when `--openshift` is set.
+* *hostname*:  The host to be used for the [ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/). Ignored when `--openshift` is set.
 * *dashboardLabelSelector*: A list of either `matchLabels` or `matchExpressions` to filter the dashboards before importing them.
 * *containers*: Extra containers to be added to the Grafana deployment. Can be used for example to add auth proxy side cars.
 * *secrets*: A list of secrets that are added as volumes to the deployment. Mostly useful in combination with extra `containers`.
 
 The other accepted properties are `logLevel`, `adminUser`, `adminPassword`, `basicAuth`, `disableLoginForm`, `disableSignoutMenu` and `anonymous`. They map to the properties described in the [official documentation](https://grafana.com/docs/installation/configuration/#configuration), just use camel case instead of underscores.
+
+*NOTE*: setting `hostname` on Ingresses is not permitted on OpenShift. We recommend using the `--openshift` flag which will use a `Route` with an automatically assigned host instead. You can still use `Ingress` on OpenShift if you don't provide a `hostname` in the `Grafana` resource.
 
 To create a new Grafana instance in the `grafana` namespace, run:
 

--- a/templates/grafana-route.yaml
+++ b/templates/grafana-route.yaml
@@ -4,7 +4,6 @@ metadata:
   name: {{ .GrafanaRouteName }}
   namespace: {{ .Namespace }}
 spec:
-  host: {{ .Hostname }}
   port:
     targetPort: grafana
   tls:


### PR DESCRIPTION
* Update the roles for the operator on OpenShift (finalizer permissions were missing) 
* Ignore the `hostname` property when using routes instead of ingress: setting the hostname is not permitted, but OpenShift will automatically assign a value.
* Document the behavior of the `hostname` property in ingresses and routes.

Verification steps:

An image with the changes has been pushed to `quay.io/integreatly/grafana-operator:latest`

1. Try this on a fresh cluster
1. Create the crds: `oc create -f deploy/crds`
1. Create the roles: `oc create -f deploy/roles`
1. Deploy the operator:
4.1. If on OpenShift, modify `operator.yaml` to include the `--openshift` flag
4.2. On Kubernetes no modification is required
1. Make sure the operator is running and no errors are in its log
1. Deploy Grafana: `oc create -f deploy/examples/Grafana.yaml`