### PR TITLE
Update default grafana image to version used in openshift 4.2 (6.2.4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,15 +13,8 @@ The Operator is functional and can deploy and manage a Grafana instance on Kuber
 
 # Operator flags
 
-The operator supports the following flags on startup:
-
-* *--grafana-image*: overrides the Grafana image, defaults to `docker.io/grafana/grafana`.
-* *--grafana-image-tag*: overrides the Grafana tag, defaults to `5.4.2`.
-* *--grafana-plugins-init-container-image*: overrides the Grafana Plugins Init Container image, defaults to `quay.io/integreatly/grafana_plugins_init`.
-* *--grafana-plugins-init-container-tag*: overrides the Grafana Plugins Init Container tag, defaults to `0.0.2`.
-* *--scan-all*: watch for dashboards in all namespaces. This requires the the operator service account to have cluster wide permissions to `get`, `list`, `update` and `watch` dashboards. See `deploy/cluster_roles`.
-* *--openshift*: force the operator to use a [route](https://docs.openshift.com/container-platform/3.11/architecture/networking/routes.html) instead of an [ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/). Note that routes are only supported on OpenShift.
-
+The operator supports the following flags on startup.
+See [the documentation](./documentation/deploy_grafana.md) for a full list.
 Flags can be passed as `args` to the container.
 
 # Supported Custom Resources

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -17,8 +17,8 @@ spec:
         - name: grafana-operator
           image: quay.io/integreatly/grafana-operator:latest
           args:
-            - '--grafana-image=docker.io/grafana/grafana'
-            - '--grafana-image-tag=5.4.2'
+            - '--grafana-image=quay.io/openshift/origin-grafana'
+            - '--grafana-image-tag=4.2'
           ports:
           - containerPort: 60000
             name: metrics

--- a/documentation/deploy_grafana.md
+++ b/documentation/deploy_grafana.md
@@ -42,9 +42,11 @@ grafana-operator-78cfcbf8db-ssrgq   1/1       Running   0          17s
 
 The operator accepts a number of flags that can be passed in the `args` section of the container in the deployment:
 
-* *--grafana-image*: overrides the Grafana image, defaults to `docker.io/grafana/grafana`.
-* *--grafana-image-tag*: overrides the Grafana tag, defaults to `5.4.2`.
-* *--scan-all*: watch for dashboards in all namespaces. This requires the the operator service account to have cluster wide permissions to `get`, `list`, `update` and `watch` dashboards. See `deploy/examples/cluster_roles`.
+* *--grafana-image*: overrides the Grafana image, defaults to `quay.io/openshift/origin-grafana`.
+* *--grafana-image-tag*: overrides the Grafana tag. See `controller_config.go` for default.
+* *--grafana-plugins-init-container-image*: overrides the Grafana Plugins Init Container image, defaults to `quay.io/integreatly/grafana_plugins_init`.
+* *--grafana-plugins-init-container-tag*: overrides the Grafana Plugins Init Container tag, defaults to `0.0.2`.
+* *--scan-all*: watch for dashboards in all namespaces. This requires the the operator service account to have cluster wide permissions to `get`, `list`, `update` and `watch` dashboards. See `deploy/cluster_roles`.
 * *--openshift*: force the operator to use a [route](https://docs.openshift.com/container-platform/3.11/architecture/networking/routes.html) instead of an [ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/). Note that routes are only supported on OpenShift.
 
 See `deploy/operator.yaml` for an example.

--- a/pkg/controller/common/controller_config.go
+++ b/pkg/controller/common/controller_config.go
@@ -2,9 +2,10 @@ package common
 
 import (
 	"fmt"
-	"github.com/integr8ly/grafana-operator/pkg/apis/integreatly/v1alpha1"
 	"sync"
 	"time"
+
+	"github.com/integr8ly/grafana-operator/pkg/apis/integreatly/v1alpha1"
 )
 
 const (
@@ -16,8 +17,8 @@ const (
 	ConfigDashboardLabelSelector    = "grafana.dashboard.selector"
 	ConfigGrafanaPluginsUpdated     = "grafana.plugins.updated"
 	ConfigOpenshift                 = "mode.openshift"
-	GrafanaImage                    = "docker.io/grafana/grafana"
-	GrafanaVersion                  = "5.4.2"
+	GrafanaImage                    = "quay.io/openshift/origin-grafana"
+	GrafanaVersion                  = "4.2"
 	LogLevel                        = "error"
 	GrafanaConfigMapName            = "grafana-config"
 	GrafanaProvidersConfigMapName   = "grafana-providers"


### PR DESCRIPTION
Downstream issue: https://issues.jboss.org/browse/INTLY-2724

Verification:

* Create a new project `oc new-project grafana`
* Install the operator from a build of this branch (`quay.io/integreatly/grafana-operator:update-grafana-version`), or alternatively run the operator locally against a remote cluster using `make code/run`
* Create a Grafana CR from the template `oc create -f ./deploy/examples/Grafana.yaml`. You may need to modify the host field before creating this, or alternatively create another route via the openshift UI after to the Grafana service.
* Go to the Grafana console & verify the version (bottom left ? symbol) is 6.2.4.