### PR TITLE
Remove the check for replicas running as it's not needed. Also, it wi…

### DIFF
--- a/pkg/controller/common/kubeHelper.go
+++ b/pkg/controller/common/kubeHelper.go
@@ -65,7 +65,7 @@ func (h KubeHelperImpl) UpdateDashboard(ns string, d *v1alpha1.GrafanaDashboard)
 }
 
 func (h KubeHelperImpl) IsKnownDataSource(ds *v1alpha1.GrafanaDataSource) (bool, error) {
-	configMap, err := h.getConfigMap(ds.Spec.Name, GrafanaDatasourcesConfigMapName)
+	configMap, err := h.getConfigMap(ds.Namespace, GrafanaDatasourcesConfigMapName)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return false, nil

--- a/pkg/controller/common/kubeHelper.go
+++ b/pkg/controller/common/kubeHelper.go
@@ -2,15 +2,16 @@ package common
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/integr8ly/grafana-operator/pkg/apis/integreatly/v1alpha1"
 	apps "k8s.io/api/apps/v1"
-	"k8s.io/api/core/v1"
 	core "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
-	"strings"
 )
 
 type KubeHelperImpl struct {
@@ -191,11 +192,6 @@ func (h KubeHelperImpl) UpdateGrafanaDeployment(monitoringNamespace string, newE
 	deployment, err := h.getGrafanaDeployment(monitoringNamespace)
 	if err != nil {
 		return err
-	}
-
-	// Leave the deployment alone when it's busy with another operation
-	if deployment.Status.Replicas != deployment.Status.ReadyReplicas {
-		return nil
 	}
 
 	updated := false


### PR DESCRIPTION
…ll prevent situations where changes don't get applied to the initContainer env var while grafana is starting.

Also, trivial fix for namespace to look for datasource configmap in. Was using the datasource name instead of namespace.