### PR TITLE
reimport dashboards after operator restart if not already imported

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -4,23 +4,23 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"github.com/integr8ly/grafana-operator/pkg/controller/common"
-	"github.com/integr8ly/grafana-operator/pkg/controller/grafanadashboard"
-	"k8s.io/client-go/rest"
-	"os"
-	"runtime"
-	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
-
 	"github.com/integr8ly/grafana-operator/pkg/apis"
 	"github.com/integr8ly/grafana-operator/pkg/controller"
+	"github.com/integr8ly/grafana-operator/pkg/controller/common"
+	"github.com/integr8ly/grafana-operator/pkg/controller/grafanadashboard"
+	"github.com/integr8ly/grafana-operator/version"
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	"github.com/operator-framework/operator-sdk/pkg/leader"
 	"github.com/operator-framework/operator-sdk/pkg/ready"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	"k8s.io/client-go/rest"
+	"os"
+	"runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
 )
 
 var log = logf.Log.WithName("cmd")
@@ -35,6 +35,7 @@ func printVersion() {
 	log.Info(fmt.Sprintf("Go Version: %s", runtime.Version()))
 	log.Info(fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH))
 	log.Info(fmt.Sprintf("operator-sdk Version: %v", sdkVersion.Version))
+	log.Info(fmt.Sprintf("operator Version: %v", version.Version))
 }
 
 func init() {

--- a/pkg/apis/integreatly/v1alpha1/grafanadashboard_types.go
+++ b/pkg/apis/integreatly/v1alpha1/grafanadashboard_types.go
@@ -4,6 +4,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const GrafanaDashboardKind = "GrafanaDashboard"
+
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 

--- a/pkg/apis/integreatly/v1alpha1/grafanadatasource_types.go
+++ b/pkg/apis/integreatly/v1alpha1/grafanadatasource_types.go
@@ -4,6 +4,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const GrafanaDataSourceKind = "GrafanaDataSource"
+
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 

--- a/pkg/apis/integreatly/v1alpha1/selectors.go
+++ b/pkg/apis/integreatly/v1alpha1/selectors.go
@@ -1,0 +1,31 @@
+package v1alpha1
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+func (d *GrafanaDashboard) matchesSelector(s *metav1.LabelSelector) (bool, error) {
+	selector, err := metav1.LabelSelectorAsSelector(s)
+	if err != nil {
+		return false, err
+	}
+
+	return selector.Empty() || selector.Matches(labels.Set(d.Labels)), nil
+}
+
+// Check if the dashboard matches at least one of the selectors
+func (d *GrafanaDashboard) MatchesSelectors(s []*metav1.LabelSelector) (bool, error) {
+	result := false
+
+	for _, selector := range s {
+		match, err := d.matchesSelector(selector)
+		if err != nil {
+			return false, err
+		}
+
+		result = result || match
+	}
+
+	return result, nil
+}

--- a/pkg/controller/common/controller_config.go
+++ b/pkg/controller/common/controller_config.go
@@ -40,7 +40,7 @@ const (
 	PluginsMinAge                   = 5
 	InitContainerName               = "grafana-plugins-init"
 	ResourceFinalizerName           = "grafana.cleanup"
-	RequeueDelaySeconds             = 10
+	RequeueDelay                    = time.Second * 15
 )
 
 type ControllerConfig struct {

--- a/pkg/controller/common/kubeHelper.go
+++ b/pkg/controller/common/kubeHelper.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	stdErrors "errors"
 	"fmt"
 	"github.com/integr8ly/grafana-operator/pkg/apis/integreatly/v1alpha1"
 	apps "k8s.io/api/apps/v1"
@@ -8,14 +9,19 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"strings"
 	"time"
 )
 
+var log = logf.Log.WithName("kube_helper")
+
 type KubeHelperImpl struct {
 	k8client *kubernetes.Clientset
+	config   *ControllerConfig
 }
 
 func NewKubeHelper() *KubeHelperImpl {
@@ -25,32 +31,41 @@ func NewKubeHelper() *KubeHelperImpl {
 
 	helper := new(KubeHelperImpl)
 	helper.k8client = k8client
+	helper.config = GetControllerConfig()
 	return helper
 }
 
-func (h KubeHelperImpl) getConfigMap(namespace, name string) (*v1.ConfigMap, error) {
-	opts := metav1.GetOptions{}
-	return h.k8client.CoreV1().ConfigMaps(namespace).Get(name, opts)
+func (h KubeHelperImpl) getConfigMapKey(namespace, name string) string {
+	return fmt.Sprintf("%s_%s", namespace, strings.ToLower(name))
 }
 
-func (h KubeHelperImpl) getGrafanaDeployment(namespaceName string) (*apps.Deployment, error) {
-	opts := metav1.GetOptions{}
-	return h.k8client.AppsV1().Deployments(namespaceName).Get(GrafanaDeploymentName, opts)
+func (h KubeHelperImpl) getConfigMap(name string) (*v1.ConfigMap, error) {
+	namespace := h.config.GetConfigString(ConfigOperatorNamespace, "")
+	return h.k8client.CoreV1().ConfigMaps(namespace).Get(name, metav1.GetOptions{})
 }
 
-func (h KubeHelperImpl) UpdateGrafanaConfig(config string, cr *v1alpha1.Grafana) error {
-	configMap, err := h.getConfigMap(cr.Namespace, GrafanaConfigMapName)
-	if err != nil {
-		return err
-	}
-
-	configMap.Data[GrafanaConfigFileName] = config
-	_, err = h.k8client.CoreV1().ConfigMaps(cr.Namespace).Update(configMap)
+func (h KubeHelperImpl) updateConfigMap(c *v1.ConfigMap) error {
+	namespace := h.config.GetConfigString(ConfigOperatorNamespace, "")
+	_, err := h.k8client.CoreV1().ConfigMaps(namespace).Update(c)
 	return err
 }
 
-func (h KubeHelperImpl) UpdateDashboard(ns string, d *v1alpha1.GrafanaDashboard) (bool, error) {
-	configMap, err := h.getConfigMap(ns, GrafanaDashboardsConfigMapName)
+func (h KubeHelperImpl) getGrafanaDeployment() (*apps.Deployment, error) {
+	namespace := h.config.GetConfigString(ConfigOperatorNamespace, "")
+	return h.k8client.AppsV1().Deployments(namespace).Get(GrafanaDeploymentName, metav1.GetOptions{})
+}
+
+func (h KubeHelperImpl) UpdateGrafanaConfig(config string, cr *v1alpha1.Grafana) error {
+	configMap, err := h.getConfigMap(GrafanaConfigMapName)
+	if err != nil {
+		return err
+	}
+	configMap.Data[GrafanaConfigFileName] = config
+	return h.updateConfigMap(configMap)
+}
+
+func (h KubeHelperImpl) UpdateDashboard(d *v1alpha1.GrafanaDashboard) (bool, error) {
+	configMap, err := h.getConfigMap(GrafanaDashboardsConfigMapName)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return false, nil
@@ -60,14 +75,13 @@ func (h KubeHelperImpl) UpdateDashboard(ns string, d *v1alpha1.GrafanaDashboard)
 
 	// Prefix the dashboard filename with the namespace to allow multiple namespaces
 	// to import the same dashboard
-	dashboardName := fmt.Sprintf("%s_%s", d.Namespace, d.Spec.Name)
-
+	dashboardName := h.getConfigMapKey(d.Namespace, d.Spec.Name)
 	if configMap.Data == nil {
 		configMap.Data = make(map[string]string)
 	}
 
 	configMap.Data[dashboardName] = d.Spec.Json
-	configMap, err = h.k8client.CoreV1().ConfigMaps(ns).Update(configMap)
+	err = h.updateConfigMap(configMap)
 	if err != nil {
 		return false, err
 	}
@@ -75,8 +89,8 @@ func (h KubeHelperImpl) UpdateDashboard(ns string, d *v1alpha1.GrafanaDashboard)
 	return true, nil
 }
 
-func (h KubeHelperImpl) IsKnownDataSource(ds *v1alpha1.GrafanaDataSource) (bool, error) {
-	configMap, err := h.getConfigMap(ds.Namespace, GrafanaDatasourcesConfigMapName)
+func (h KubeHelperImpl) isKnown(config, namespace, name string) (bool, error) {
+	configMap, err := h.getConfigMap(config)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return false, nil
@@ -88,14 +102,26 @@ func (h KubeHelperImpl) IsKnownDataSource(ds *v1alpha1.GrafanaDataSource) (bool,
 		return false, nil
 	}
 
-	key := fmt.Sprintf("%s_%s", ds.Namespace, strings.ToLower(ds.Spec.Name))
+	key := h.getConfigMapKey(namespace, name)
 	_, found := configMap.Data[key]
-
 	return found, nil
 }
 
+func (h KubeHelperImpl) IsKnown(kind string, o runtime.Object) (bool, error) {
+	switch kind {
+	case v1alpha1.GrafanaDashboardKind:
+		d := o.(*v1alpha1.GrafanaDashboard)
+		return h.isKnown(GrafanaDashboardsConfigMapName, d.Namespace, d.Spec.Name)
+	case v1alpha1.GrafanaDataSourceKind:
+		d := o.(*v1alpha1.GrafanaDataSource)
+		return h.isKnown(GrafanaDatasourcesConfigMapName, d.Namespace, d.Spec.Name)
+	default:
+		return false, stdErrors.New(fmt.Sprintf("unknown kind '%v'", kind))
+	}
+}
+
 func (h KubeHelperImpl) UpdateDataSources(name, namespace, ds string) (bool, error) {
-	configMap, err := h.getConfigMap(namespace, GrafanaDatasourcesConfigMapName)
+	configMap, err := h.getConfigMap(GrafanaDatasourcesConfigMapName)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return false, nil
@@ -105,14 +131,14 @@ func (h KubeHelperImpl) UpdateDataSources(name, namespace, ds string) (bool, err
 
 	// Prefix the data source filename with the namespace to allow multiple namespaces
 	// to import the same dashboard
-	key := fmt.Sprintf("%s_%s", namespace, strings.ToLower(name))
+	key := h.getConfigMapKey(namespace, name)
 
 	if configMap.Data == nil {
 		configMap.Data = make(map[string]string)
 	}
 
 	configMap.Data[key] = ds
-	configMap, err = h.k8client.CoreV1().ConfigMaps(namespace).Update(configMap)
+	err = h.updateConfigMap(configMap)
 	if err != nil {
 		return false, err
 	}
@@ -120,7 +146,7 @@ func (h KubeHelperImpl) UpdateDataSources(name, namespace, ds string) (bool, err
 }
 
 func (h KubeHelperImpl) DeleteDataSources(name, namespace string) error {
-	configMap, err := h.getConfigMap(namespace, GrafanaDatasourcesConfigMapName)
+	configMap, err := h.getConfigMap(GrafanaDatasourcesConfigMapName)
 	if err != nil {
 		// Grafana may already be uninstalled
 		if errors.IsNotFound(err) {
@@ -131,7 +157,7 @@ func (h KubeHelperImpl) DeleteDataSources(name, namespace string) error {
 
 	// Prefix the dashboard filename with the namespace to allow multiple namespaces
 	// to import the same dashboard
-	key := fmt.Sprintf("%s_%s", namespace, strings.ToLower(name))
+	key := h.getConfigMapKey(namespace, name)
 
 	if configMap.Data == nil {
 		return nil
@@ -143,12 +169,12 @@ func (h KubeHelperImpl) DeleteDataSources(name, namespace string) error {
 	}
 
 	delete(configMap.Data, key)
-	configMap, err = h.k8client.CoreV1().ConfigMaps(namespace).Update(configMap)
+	err = h.updateConfigMap(configMap)
 	return err
 }
 
-func (h KubeHelperImpl) DeleteDashboard(monitoringNamespace string, dashboardNamespace string, dashboard *v1alpha1.GrafanaDashboard) error {
-	configMap, err := h.getConfigMap(monitoringNamespace, GrafanaDashboardsConfigMapName)
+func (h KubeHelperImpl) DeleteDashboard(d *v1alpha1.GrafanaDashboard) error {
+	configMap, err := h.getConfigMap(GrafanaDashboardsConfigMapName)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// Grafana may already be uninstalled
@@ -157,10 +183,7 @@ func (h KubeHelperImpl) DeleteDashboard(monitoringNamespace string, dashboardNam
 		return err
 	}
 
-	// Prefix the dashboard filename with the namespace to allow multiple namespaces
-	// to import the same dashboard
-	dashboardName := fmt.Sprintf("%s_%s", dashboardNamespace, dashboard.Spec.Name)
-
+	dashboardName := h.getConfigMapKey(d.Namespace, d.Spec.Name)
 	if configMap.Data == nil {
 		return nil
 	}
@@ -171,7 +194,7 @@ func (h KubeHelperImpl) DeleteDashboard(monitoringNamespace string, dashboardNam
 	}
 
 	delete(configMap.Data, dashboardName)
-	configMap, err = h.k8client.CoreV1().ConfigMaps(monitoringNamespace).Update(configMap)
+	err = h.updateConfigMap(configMap)
 	if err != nil {
 		return err
 	}
@@ -199,8 +222,10 @@ func (h KubeHelperImpl) getGrafanaPod(namespaceName string) (*core.Pod, error) {
 	return &pods.Items[0], nil
 }
 
-func (h KubeHelperImpl) UpdateGrafanaDeployment(monitoringNamespace string, newEnv string) error {
-	deployment, err := h.getGrafanaDeployment(monitoringNamespace)
+func (h KubeHelperImpl) UpdateGrafanaDeployment(newEnv string) error {
+	monitoringNamespace := h.config.GetConfigString(ConfigOperatorNamespace, "")
+	deployment, err := h.getGrafanaDeployment()
+
 	if err != nil {
 		return err
 	}
@@ -228,8 +253,10 @@ func (h KubeHelperImpl) UpdateGrafanaDeployment(monitoringNamespace string, newE
 	return nil
 }
 
-func (h KubeHelperImpl) RestartGrafana(monitoringNamespace string) error {
+func (h KubeHelperImpl) RestartGrafana() error {
+	monitoringNamespace := h.config.GetConfigString(ConfigOperatorNamespace, "")
 	pod, err := h.getGrafanaPod(monitoringNamespace)
+
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// No need to restart if grafana has not yet been deployed

--- a/pkg/controller/common/resource_states.go
+++ b/pkg/controller/common/resource_states.go
@@ -4,4 +4,5 @@ const (
 	StatusResourceUninitialized int = iota
 	StatusResourceSetFinalizer
 	StatusResourceCreated
+	StatusResourceOrphaned
 )

--- a/pkg/controller/grafanadashboard/dashboard_controller.go
+++ b/pkg/controller/grafanadashboard/dashboard_controller.go
@@ -7,13 +7,10 @@ import (
 	"fmt"
 	i8ly "github.com/integr8ly/grafana-operator/pkg/apis/integreatly/v1alpha1"
 	"github.com/integr8ly/grafana-operator/pkg/controller/common"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/util/json"
-	"time"
-
 	"k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/json"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -75,36 +72,12 @@ type ReconcileGrafanaDashboard struct {
 	helper *common.KubeHelperImpl
 }
 
-func (r *ReconcileGrafanaDashboard) matchesSelector(d *i8ly.GrafanaDashboard, s *v1.LabelSelector) (bool, error) {
-	selector, err := v1.LabelSelectorAsSelector(s)
-	if err != nil {
-		return false, err
-	}
-
-	return selector.Empty() || selector.Matches(labels.Set(d.Labels)), nil
-}
-
-func (r *ReconcileGrafanaDashboard) matchesSelectors(d *i8ly.GrafanaDashboard, s []*v1.LabelSelector) (bool, error) {
-	result := false
-
-	for _, selector := range s {
-		match, err := r.matchesSelector(d, selector)
-		if err != nil {
-			return false, err
-		}
-
-		result = result || match
-	}
-
-	return result, nil
-}
-
 // The Controller will requeue the Request to be processed again if the returned error is non-nil or
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
 func (r *ReconcileGrafanaDashboard) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	dashboardLabelSelectors := r.config.GetConfigItem(common.ConfigDashboardLabelSelector, nil)
 	if dashboardLabelSelectors == nil {
-		return reconcile.Result{RequeueAfter: time.Second * 10}, nil
+		return reconcile.Result{RequeueAfter: common.RequeueDelay}, nil
 	}
 
 	// Fetch the GrafanaDashboard instance
@@ -122,7 +95,7 @@ func (r *ReconcileGrafanaDashboard) Reconcile(request reconcile.Request) (reconc
 	}
 
 	cr := instance.DeepCopy()
-	if match, err := r.matchesSelectors(cr, dashboardLabelSelectors.([]*v1.LabelSelector)); err != nil {
+	if match, err := cr.MatchesSelectors(dashboardLabelSelectors.([]*v1.LabelSelector)); err != nil {
 		return reconcile.Result{}, err
 	} else if !match {
 		log.Info(fmt.Sprintf("found dashboard '%s/%s' but labels do not match", cr.Namespace, cr.Name))
@@ -156,8 +129,18 @@ func (r *ReconcileGrafanaDashboard) Reconcile(request reconcile.Request) (reconc
 func (r *ReconcileGrafanaDashboard) checkPrerequisites(d *i8ly.GrafanaDashboard) bool {
 	changed, hash := r.hasDashboardChanged(d)
 	if !changed {
-		log.Info("dashboard reconciled but no changes")
-		return false
+		known, err := r.helper.IsKnown(i8ly.GrafanaDashboardKind, d)
+		if err != nil {
+			log.Error(err, "error checking dashboard status")
+			return false
+		}
+
+		// If the dashboard is known and unchanged we don't have to
+		// import it again
+		if known {
+			log.Info("dashboard reconciled but no changes")
+			return false
+		}
 	}
 	d.Status.LastConfig = hash
 
@@ -196,13 +179,13 @@ func (r *ReconcileGrafanaDashboard) importDashboard(d *i8ly.GrafanaDashboard) (r
 		return reconcile.Result{Requeue: false}, nil
 	}
 
-	updated, err := r.helper.UpdateDashboard(operatorNamespace, d)
+	updated, err := r.helper.UpdateDashboard(d)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
 
 	if !updated {
-		return reconcile.Result{RequeueAfter: time.Second * common.RequeueDelaySeconds}, err
+		return reconcile.Result{RequeueAfter: common.RequeueDelay}, err
 	}
 
 	// Reconcile dashboard plugins
@@ -226,7 +209,7 @@ func (r *ReconcileGrafanaDashboard) deleteDashboard(d *i8ly.GrafanaDashboard) (r
 		return reconcile.Result{}, defaultErrors.New("no monitoring namespace set")
 	}
 
-	err := r.helper.DeleteDashboard(operatorNamespace, d.Namespace, d)
+	err := r.helper.DeleteDashboard(d)
 	if err == nil {
 		log.Info(fmt.Sprintf("dashboard '%s/%s' deleted", d.Namespace, d.Spec.Name))
 	}

--- a/pkg/controller/grafanadatasource/datasource_controller.go
+++ b/pkg/controller/grafanadatasource/datasource_controller.go
@@ -7,8 +7,6 @@ import (
 	"github.com/ghodss/yaml"
 	i8ly "github.com/integr8ly/grafana-operator/pkg/apis/integreatly/v1alpha1"
 	"github.com/integr8ly/grafana-operator/pkg/controller/common"
-	"time"
-
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -120,7 +118,7 @@ func (r *ReconcileGrafanaDataSource) reconcileDatasource(cr *i8ly.GrafanaDataSou
 		return reconcile.Result{}, err
 	}
 
-	known, err := r.helper.IsKnownDataSource(cr)
+	known, err := r.helper.IsKnown(i8ly.GrafanaDataSourceKind, cr)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -142,10 +140,10 @@ func (r *ReconcileGrafanaDataSource) reconcileDatasource(cr *i8ly.GrafanaDataSou
 	}
 
 	if !updated {
-		return reconcile.Result{RequeueAfter: time.Second * common.RequeueDelaySeconds}, err
+		return reconcile.Result{RequeueAfter: common.RequeueDelay}, err
 	}
 
-	err = r.helper.RestartGrafana(cr.Namespace)
+	err = r.helper.RestartGrafana()
 	if err != nil {
 		log.Error(err, "error restarting grafana")
 	}
@@ -171,7 +169,7 @@ func (r *ReconcileGrafanaDataSource) DeleteDatasource(cr *i8ly.GrafanaDataSource
 		log.Error(err, "error removing finalizer")
 	}
 
-	err = r.helper.RestartGrafana(cr.Namespace)
+	err = r.helper.RestartGrafana()
 	if err != nil {
 		log.Error(err, "error restarting grafana")
 	}

--- a/pkg/controller/grafanadatasource/datasource_controller.go
+++ b/pkg/controller/grafanadatasource/datasource_controller.go
@@ -105,7 +105,13 @@ func (r *ReconcileGrafanaDataSource) Reconcile(request reconcile.Request) (recon
 			return r.setFinalizer(cr)
 		}
 	case common.StatusResourceCreated:
-		return r.reconcileDatasource(cr)
+		res, err := r.reconcileDatasource(cr)
+
+		// Requeue periodically to find datasources that have not been updated
+		// but are not yet imported (can happen if Grafana is uninstalled and
+		// then reinstalled without an Operator restart
+		res.RequeueAfter = common.RequeueDelay
+		return res, err
 	default:
 		return reconcile.Result{}, nil
 	}


### PR DESCRIPTION
When Grafana is uninstalled and then reinstalled (by deleting and recreating the CR) without restarting the operator, dashboards that were imported previously will no longer be discovered. This is because the dashboards are already marked as imported and as long as they are not updated the Operator will not attempt to re import them.

There are two ways to fix this:

1) Introduce the concept of 'orphaned' dashboards: When Grafana is uninstalled, the operator would list all dashboards and set them to status `orphaned`. In this status, the dashboard controller continually reschedules them. It will do this as long as there are dashboards and no Grafana installation. When Grafana is reinstalled, it would move the dashboard back into a `ready for import` status and stop the periodic scheduling.

2) Always reschedule dashboards periodically.

Since option 1 introduces a lot of complexity and a state dependency between the dashboard and grafana controllers i'd like to avoid it. Option 2 is very simple and the rescheduling only happens every 15 seconds.

This PR also has some refactoring and cleanup.

Fixes #31 

Verification steps:

1. Run the operator from this branch
2. Deploy Grafana
3. Create a dashboard and a datasource
4. Make sure both are imported into the configmaps
5. Uninstall Grafana by deleting the CR
6. Do not restart the Operator
7. Install Grafana again
8. Make sure the dashboard and datasource are discovered (can take ~30 seconds)
9. Try the same but this time with a restart inbetween, it should also work.