### PR TITLE
Customize pod label

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -28,6 +28,7 @@ var flagImage string
 var flagImageTag string
 var flagPluginsInitContainerImage string
 var flagPluginsInitContainerTag string
+var flagPodLabelValue string
 var scanAll bool
 var openshift bool
 
@@ -44,6 +45,7 @@ func init() {
 	flagset.StringVar(&flagImageTag, "grafana-image-tag", "", "Overrides the default Grafana image tag")
 	flagset.StringVar(&flagPluginsInitContainerImage, "grafana-plugins-init-container-image", "", "Overrides the default Grafana Plugins Init Container image")
 	flagset.StringVar(&flagPluginsInitContainerTag, "grafana-plugins-init-container-tag", "", "Overrides the default Grafana Plugins Init Container tag")
+	flagset.StringVar(&flagPodLabelValue, "pod-label-value", common.PodLabelDefaultValue, "Overrides the default value of the app label")
 	flagset.BoolVar(&scanAll, "scan-all", false, "Scans all namespaces for dashboards")
 	flagset.BoolVar(&openshift, "openshift", false, "Use Route instead of Ingress")
 	flagset.Parse(os.Args[1:])
@@ -96,6 +98,7 @@ func main() {
 	controllerConfig.AddConfigItem(common.ConfigGrafanaImageTag, flagImageTag)
 	controllerConfig.AddConfigItem(common.ConfigPluginsInitContainerImage, flagPluginsInitContainerImage)
 	controllerConfig.AddConfigItem(common.ConfigPluginsInitContainerTag, flagPluginsInitContainerTag)
+	controllerConfig.AddConfigItem(common.ConfigPodLabelValue, flagPodLabelValue)
 	controllerConfig.AddConfigItem(common.ConfigOperatorNamespace, namespace)
 	controllerConfig.AddConfigItem(common.ConfigDashboardLabelSelector, "")
 	controllerConfig.AddConfigItem(common.ConfigOpenshift, openshift)

--- a/documentation/deploy_grafana.md
+++ b/documentation/deploy_grafana.md
@@ -48,6 +48,8 @@ The operator accepts a number of flags that can be passed in the `args` section 
 * *--grafana-plugins-init-container-tag*: overrides the Grafana Plugins Init Container tag, defaults to `0.0.2`.
 * *--scan-all*: watch for dashboards in all namespaces. This requires the the operator service account to have cluster wide permissions to `get`, `list`, `update` and `watch` dashboards. See `deploy/cluster_roles`.
 * *--openshift*: force the operator to use a [route](https://docs.openshift.com/container-platform/3.11/architecture/networking/routes.html) instead of an [ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/). Note that routes are only supported on OpenShift.
+* *--pod-label-value*: override the value of the `app` label that gets attached to pods and other resources.
+
 
 See `deploy/operator.yaml` for an example.
 

--- a/pkg/controller/common/controller_config.go
+++ b/pkg/controller/common/controller_config.go
@@ -13,6 +13,7 @@ const (
 	ConfigGrafanaImageTag           = "grafana.image.tag"
 	ConfigPluginsInitContainerImage = "grafana.plugins.init.container.image.url"
 	ConfigPluginsInitContainerTag   = "grafana.plugins.init.container.image.tag"
+	ConfigPodLabelValue             = "grafana.pod.label"
 	ConfigOperatorNamespace         = "grafana.operator.namespace"
 	ConfigDashboardLabelSelector    = "grafana.dashboard.selector"
 	ConfigGrafanaPluginsUpdated     = "grafana.plugins.updated"
@@ -41,6 +42,7 @@ const (
 	InitContainerName               = "grafana-plugins-init"
 	ResourceFinalizerName           = "grafana.cleanup"
 	RequeueDelay                    = time.Second * 15
+	PodLabelDefaultValue            = "grafana"
 )
 
 type ControllerConfig struct {

--- a/pkg/controller/common/kubeHelper.go
+++ b/pkg/controller/common/kubeHelper.go
@@ -203,8 +203,10 @@ func (h KubeHelperImpl) DeleteDashboard(d *v1alpha1.GrafanaDashboard) error {
 }
 
 func (h KubeHelperImpl) getGrafanaPod(namespaceName string) (*core.Pod, error) {
+	podLabel := h.config.GetConfigString(ConfigPodLabelValue, PodLabelDefaultValue)
+
 	opts := metav1.ListOptions{
-		LabelSelector: "app=grafana",
+		LabelSelector: fmt.Sprintf("app=%s", podLabel),
 	}
 
 	pods, err := h.k8client.CoreV1().Pods(namespaceName).List(opts)

--- a/pkg/controller/grafana/templateHelper.go
+++ b/pkg/controller/grafana/templateHelper.go
@@ -35,6 +35,7 @@ type GrafanaParamaeters struct {
 	Hostname                        string
 	AdminUser                       string
 	AdminPassword                   string
+	PodLabelValue                   string
 	BasicAuth                       bool
 	DisableLoginForm                bool
 	DisableSignoutMenu              bool
@@ -102,6 +103,7 @@ func newTemplateHelper(cr *integreatly.Grafana) *TemplateHelper {
 		DisableLoginForm:                cr.Spec.DisableLoginForm,
 		DisableSignoutMenu:              cr.Spec.DisableSignoutMenu,
 		Anonymous:                       cr.Spec.Anonymous,
+		PodLabelValue:                   controllerConfig.GetConfigString(common.ConfigPodLabelValue, common.PodLabelDefaultValue),
 	}
 
 	templatePath := os.Getenv("TEMPLATE_PATH")

--- a/templates/grafana-deployment.yaml
+++ b/templates/grafana-deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: grafana
+    app: {{ .PodLabelValue }}
   name: {{ .GrafanaDeploymentName }}
   namespace: {{ .Namespace }}
 spec:
@@ -10,7 +10,7 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app: grafana
+      app: {{ .PodLabelValue }}
   strategy:
     rollingUpdate:
       maxSurge: 1
@@ -20,7 +20,7 @@ spec:
     metadata:
       creationTimestamp: null
       labels:
-        app: grafana
+        app: {{ .PodLabelValue }}
       name: grafana
     spec:
       initContainers:

--- a/templates/grafana-ingress.yaml
+++ b/templates/grafana-ingress.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ .GrafanaIngressName }}
   namespace: {{ .Namespace }}
   labels:
-    app: grafana
+    app: {{ .PodLabelValue }}
 spec:
   rules:
     - host: {{ .Hostname }}

--- a/templates/grafana-service.yaml
+++ b/templates/grafana-service.yaml
@@ -12,4 +12,4 @@ spec:
     protocol: TCP
     targetPort: grafana-http
   selector:
-    app: grafana
+    app: {{ .PodLabelValue }}


### PR DESCRIPTION
Allow users to customize the value of the label that is assigend to the grafana pod. This can be useful in scenarios where another unmanaged grafana instance is running in the same namespace.

I prefer to use an operator flag instead of a CR property to make it clearer that this is not to support multiple managed grafana instances.

Implements #37 

Verification steps:

1. Deploy the operator using the ` customize-pod-label ` tag
2. Provide an extra operator flag `--pod-label-value=grafana2`
3. Install grafana
4. Make sure everything still works as expected (access UI, import dashboar and data source).
5. Make sure the pod is labelled `grafana2`

@jjaferson mind taking a look?