### PR TITLE
Periodically reconcile oauth annotations onto the grafana service account

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 var (
-	Version = "1.3.1"
+	Version = "1.3.2"
 )


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/INTLY-3843

Related PRs:
- https://github.com/integr8ly/manifests/pull/75
- https://github.com/integr8ly/application-monitoring-operator/pull/87
- https://github.com/integr8ly/application-monitoring-operator/pull/88
- https://github.com/integr8ly/integreatly-operator/pull/142
- https://github.com/integr8ly/installation/pull/1075/files

Periodically reconcile the service accounts for Grafana Prometheus and AlertManager to make sure the annotations are in place.

Bumping integreatly operator version 1.9.5
Bumping application monitoring operator version 0.0.28
Bumping grafana operator version 1.3.2