### PR TITLE
Kube support

### DIFF
--- a/deploy/cluster_roles/cluster_role.yaml
+++ b/deploy/cluster_roles/cluster_role.yaml
@@ -7,5 +7,5 @@ rules:
       - integreatly.org
     resources:
       - grafanadashboards
-      - grafanadashboards/finalizers
+      - grafanadashboards/status
     verbs: ['get', 'list', 'update', 'watch']

--- a/deploy/roles/role.yaml
+++ b/deploy/roles/role.yaml
@@ -50,10 +50,10 @@ rules:
   resources:
   - grafanas/status
   - grafanas
+  - grafanas/status
   - grafanadashboards
+  - grafanadashboards/status
   - grafanadatasources
-  - grafanas/finalizers
-  - grafanadashboards/finalizers
-  - grafanadatasources/finalizers
+  - grafanadatasources/status
   verbs:
   - '*'

--- a/pkg/controller/common/readiness_checks.go
+++ b/pkg/controller/common/readiness_checks.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	v1 "github.com/openshift/api/route/v1"
 	v12 "k8s.io/api/apps/v1"
+	"k8s.io/api/extensions/v1beta1"
 )
 
 const (
@@ -24,6 +25,14 @@ func IsRouteReady(route *v1.Route) bool {
 		}
 	}
 	return true
+}
+
+func IsIngressReady(ingress *v1beta1.Ingress) bool {
+	if ingress == nil {
+		return false
+	}
+
+	return len(ingress.Status.LoadBalancer.Ingress) > 0
 }
 
 func IsDeploymentReady(deployment *v12.Deployment) (bool, error) {

--- a/pkg/controller/grafana/grafana_reconciler.go
+++ b/pkg/controller/grafana/grafana_reconciler.go
@@ -51,9 +51,16 @@ func (i *GrafanaReconciler) getGrafanaReadiness(state *common.ClusterState, cr *
 	cfg := config.GetControllerConfig()
 	openshift := cfg.GetConfigBool(config.ConfigOpenshift, false)
 	if openshift && cr.Spec.Ingress != nil && cr.Spec.Ingress.Enabled {
+		// On OpenShift, check the route
 		actions = append(actions, common.RouteReadyAction{
 			Ref: state.GrafanaRoute,
 			Msg: "check route readiness",
+		})
+	} else if !openshift && cr.Spec.Ingress != nil && cr.Spec.Ingress.Enabled {
+		// On vanilla Kubernetes, check the ingress
+		actions = append(actions, common.IngressReadyAction{
+			Ref: state.GrafanaIngress,
+			Msg: "check ingress readiness",
 		})
 	}
 

--- a/pkg/controller/grafanadashboard/dashboard_controller.go
+++ b/pkg/controller/grafanadashboard/dashboard_controller.go
@@ -211,6 +211,7 @@ func (r *ReconcileGrafanaDashboard) reconcileDashboards(request reconcile.Reques
 		knownHash := findHash(&dashboard)
 		pipeline := NewDashboardPipeline(&dashboard)
 		processed, err := pipeline.ProcessDashboard(knownHash)
+
 		if err != nil {
 			r.manageError(&dashboard, err)
 			continue

--- a/pkg/controller/grafanadashboard/grafana_client.go
+++ b/pkg/controller/grafanadashboard/grafana_client.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"time"
 )
 
 const (
@@ -36,6 +37,7 @@ func NewGrafanaClient(url, user, password string) GrafanaClient {
 
 	client := &http.Client{
 		Transport: &transport,
+		Timeout:   time.Second * 2,
 	}
 
 	return &GrafanaClientImpl{


### PR DESCRIPTION
updates to ensure the operator works on vanilla kubernetes. Grafana api client must be able to connect to Grafana with or without an Ingress.