### PR TITLE
add grafana/postgres ha example

### DIFF
--- a/deploy/examples/ha/README.md
+++ b/deploy/examples/ha/README.md
@@ -1,0 +1,15 @@
+# High Availability Deployment
+
+This example demonstrates how to deploy Grafana in high availability mode running multiple replicas and using Postgres as a database.
+
+Grafana will by default also use the database for session storage. To keep user sessions separate, the `remote_cache` configuration can be used. 
+
+## Installation
+
+1. Make sure the operator is running, then create the templates in this directory:
+
+```shell script
+$ kubectl apply -f deploy/examples/ha
+```
+
+*NOTE:* This examples uses an `emptyDir` storage for Postgres and is only meant for demo purposes.

--- a/deploy/examples/ha/grafana.yaml
+++ b/deploy/examples/ha/grafana.yaml
@@ -1,0 +1,27 @@
+apiVersion: integreatly.org/v1alpha1
+kind: Grafana
+metadata:
+  name: example-grafana
+spec:
+  deployment:
+    replicas: 2
+  ingress:
+    enabled: True
+  config:
+    log:
+      mode: "console"
+      level: "warn"
+    auth:
+      disable_login_form: False
+      disable_signout_menu: True
+    auth.anonymous:
+      enabled: True
+    database:
+      type: postgres
+      host: postgres:5432
+      name: grafana
+      user: grafana
+      password: grafana
+  dashboardLabelSelector:
+    - matchExpressions:
+        - {key: app, operator: In, values: [grafana]}

--- a/deploy/examples/ha/postgres.yaml
+++ b/deploy/examples/ha/postgres.yaml
@@ -1,0 +1,60 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  labels:
+    app: postgres
+spec:
+  ports:
+    - port: 5432
+      targetPort: 5432
+      name: postgres
+  selector:
+    app: postgres
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: postgres
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:11.5
+          imagePullPolicy: "IfNotPresent"
+          livenessProbe:
+            timeoutSeconds: 1
+            initialDelaySeconds: 5
+            tcpSocket:
+              port: 5432
+          readinessProbe:
+            timeoutSeconds: 1
+            initialDelaySeconds: 5
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - psql -h 127.0.0.1 -U $POSTGRES_USER -q -d $POSTGRES_DB -c 'SELECT 1'
+          ports:
+            - containerPort: 5432
+          env:
+            - name: POSTGRES_USER
+              value: grafana
+            - name: POSTGRES_PASSWORD
+              value: grafana
+            - name: POSTGRES_DB
+              value: grafana
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          volumeMounts:
+            - mountPath: /var/lib/postgresql/data
+              name: postgredb
+      volumes:
+        - name: postgredb
+          emptyDir: {}

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -16,6 +16,7 @@ The following example CRs are provided:
 * [GrafanaWithIngressHost.yaml](../deploy/examples/GrafanaWithIngressHost.yaml): Installs Grafana using the default configuration and an Ingress where the host is set for external access. 
 * [ldap/Grafana.yaml](../deploy/examples/ldap/Grafana.yaml): Installs Grafana and sets up LDAP authentication. LDAP configuration is mounted from the configmap [ldap/ldap-config.yaml](../deploy/examples/ldap/ldap-config.yaml)
 * [oauth/Grafana.yaml](../deploy/examples/oauth/Grafana.yaml): Installs Grafana and enable OAuth authentication using the OpenShift OAuthProxy. 
+* [ha/Grafana.yaml](../deploy/examples/oauth/Grafana.yaml): Installs Grafana in high availability mode with Postgres as a database. 
 
 ### Dashboards
 

--- a/pkg/controller/config/grafanaIni.go
+++ b/pkg/controller/config/grafanaIni.go
@@ -99,7 +99,7 @@ func (i *GrafanaIni) Write() (string, string) {
 	if i.cfg.RemoteCache != nil {
 		var items []string
 		items = appendStr(items, "type", i.cfg.RemoteCache.Type)
-		items = appendStr(items, "type", i.cfg.RemoteCache.ConnStr)
+		items = appendStr(items, "connstr", i.cfg.RemoteCache.ConnStr)
 		config["remote_cache"] = items
 	}
 


### PR DESCRIPTION
Adds a high availability example where Postgres is used as a backing database for Grafana.

Provides a solution for: #63 

Verification steps:

* follow the steps described in https://github.com/integr8ly/grafana-operator/compare/master...pb82:grafana-ha?expand=1#diff-97febf83a0872839b69a71afa6b2e9ca
* Get the login credentials from the secret `grafana-admin-credentials`
* Login using the route, make sure that the session is not lost after multiple browser refreshes.