### PR TITLE
fix configmap prefix

### DIFF
--- a/pkg/controller/model/grafanaDeployment.go
+++ b/pkg/controller/model/grafanaDeployment.go
@@ -145,7 +145,7 @@ func getVolumes(cr *v1alpha1.Grafana) []v13.Volume {
 
 	// Extra volumes for config maps
 	for _, configmap := range cr.Spec.ConfigMaps {
-		volumeName := fmt.Sprintf("secret-%s", configmap)
+		volumeName := fmt.Sprintf("configmap-%s", configmap)
 		volumes = append(volumes, v13.Volume{
 			Name: volumeName,
 			VolumeSource: v13.VolumeSource{


### PR DESCRIPTION
Use correct prefix for volumes created from configmaps.

Fixes #88 

Verification steps:

* Use the ldap example: https://github.com/integr8ly/grafana-operator/tree/master/deploy/examples/ldap
* Create the configmap
* Deploy Grafana using Grafana.yaml

Deployment should get created and the container should have a file ldap.toml mounted under `/etc/grafana-configmaps/ldap-config/ldap.toml`. 