### PR TITLE
operator.yaml - update so it deploys the latest grafana image as set by the operator by default

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -16,9 +16,7 @@ spec:
       containers:
         - name: grafana-operator
           image: quay.io/integreatly/grafana-operator:latest
-          args:
-            - '--grafana-image=quay.io/openshift/origin-grafana'
-            - '--grafana-image-tag=4.2'
+          args: []
           ports:
           - containerPort: 60000
             name: metrics


### PR DESCRIPTION
The latest release of this operator says it deploys Grafana 6.5.1 but with the current defaults in the operator.yml 6.2.something gets deployed. suggest removing the args in the operatyor.yml so by default the default image set in the operator gets picked up