### PR TITLE
deploy/operator.yaml - update stratigy to be recreate since rolling wont work with an operator where only one pod can be the master

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -7,6 +7,8 @@ spec:
   selector:
     matchLabels:
       name: grafana-operator
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:


### PR DESCRIPTION
since only one operator pod can be master at a time with the default deployment strategy for `rolling` the roll never successfully happens because the old pod is staying up till the new pod is healthy but the new pod can never be healthy because its not the leader. for operator best to just set strategy to `recreate`