### PR TITLE
roles/role.yaml - add 'routes/custom-host' so that custom host can be set

### DIFF
--- a/deploy/roles/role.yaml
+++ b/deploy/roles/role.yaml
@@ -49,6 +49,7 @@ rules:
       - route.openshift.io
     resources:
       - routes
+      - routes/custom-host
     verbs:
       - get
       - list


### PR DESCRIPTION
need this permission to be able to use the `GrafanaWithIngressHost.yaml` on OpenShift.