### PR TITLE
merge annotations

### DIFF
--- a/pkg/controller/model/grafanaIngress.go
+++ b/pkg/controller/model/grafanaIngress.go
@@ -53,7 +53,7 @@ func GrafanaIngress(cr *v1alpha1.Grafana) *v1beta1.Ingress {
 			Name:        GrafanaIngressName,
 			Namespace:   cr.Namespace,
 			Labels:      GetIngressLabels(cr),
-			Annotations: GetIngressAnnotations(cr),
+			Annotations: GetIngressAnnotations(cr, nil),
 		},
 		Spec: getIngressSpec(cr),
 	}
@@ -62,7 +62,7 @@ func GrafanaIngress(cr *v1alpha1.Grafana) *v1beta1.Ingress {
 func GrafanaIngressReconciled(cr *v1alpha1.Grafana, currentState *v1beta1.Ingress) *v1beta1.Ingress {
 	reconciled := currentState.DeepCopy()
 	reconciled.Labels = GetIngressLabels(cr)
-	reconciled.Annotations = GetIngressAnnotations(cr)
+	reconciled.Annotations = GetIngressAnnotations(cr, currentState.Annotations)
 	reconciled.Spec = getIngressSpec(cr)
 	return reconciled
 }

--- a/pkg/controller/model/grafanaRoute.go
+++ b/pkg/controller/model/grafanaRoute.go
@@ -29,11 +29,11 @@ func GetIngressLabels(cr *v1alpha1.Grafana) map[string]string {
 	return cr.Spec.Ingress.Labels
 }
 
-func GetIngressAnnotations(cr *v1alpha1.Grafana) map[string]string {
+func GetIngressAnnotations(cr *v1alpha1.Grafana, existing map[string]string) map[string]string {
 	if cr.Spec.Ingress == nil {
-		return nil
+		return existing
 	}
-	return cr.Spec.Ingress.Annotations
+	return MergeAnnotations(cr.Spec.Ingress.Annotations, existing)
 }
 
 func GetIngressTargetPort(cr *v1alpha1.Grafana) intstr.IntOrString {
@@ -92,7 +92,7 @@ func GrafanaRoute(cr *v1alpha1.Grafana) *v1.Route {
 			Name:        GrafanaRouteName,
 			Namespace:   cr.Namespace,
 			Labels:      GetIngressLabels(cr),
-			Annotations: GetIngressAnnotations(cr),
+			Annotations: GetIngressAnnotations(cr, nil),
 		},
 		Spec: getRouteSpec(cr),
 	}
@@ -108,7 +108,7 @@ func GrafanaRouteSelector(cr *v1alpha1.Grafana) client.ObjectKey {
 func GrafanaRouteReconciled(cr *v1alpha1.Grafana, currentState *v1.Route) *v1.Route {
 	reconciled := currentState.DeepCopy()
 	reconciled.Labels = GetIngressLabels(cr)
-	reconciled.Annotations = GetIngressAnnotations(cr)
+	reconciled.Annotations = GetIngressAnnotations(cr, currentState.Annotations)
 	reconciled.Spec = getRouteSpec(cr)
 	return reconciled
 }

--- a/pkg/controller/model/grafanaService.go
+++ b/pkg/controller/model/grafanaService.go
@@ -16,11 +16,12 @@ func getServiceLabels(cr *v1alpha1.Grafana) map[string]string {
 	return cr.Spec.Service.Labels
 }
 
-func getServiceAnnotations(cr *v1alpha1.Grafana) map[string]string {
+func getServiceAnnotations(cr *v1alpha1.Grafana, existing map[string]string) map[string]string {
 	if cr.Spec.Service == nil {
-		return nil
+		return existing
 	}
-	return cr.Spec.Service.Annotations
+
+	return MergeAnnotations(cr.Spec.Service.Annotations, existing)
 }
 
 func getServiceType(cr *v1alpha1.Grafana) v1.ServiceType {
@@ -99,7 +100,7 @@ func GrafanaService(cr *v1alpha1.Grafana) *v1.Service {
 			Name:        GrafanaServiceName,
 			Namespace:   cr.Namespace,
 			Labels:      getServiceLabels(cr),
-			Annotations: getServiceAnnotations(cr),
+			Annotations: getServiceAnnotations(cr, nil),
 		},
 		Spec: v1.ServiceSpec{
 			Ports: getServicePorts(cr, nil),
@@ -115,7 +116,7 @@ func GrafanaService(cr *v1alpha1.Grafana) *v1.Service {
 func GrafanaServiceReconciled(cr *v1alpha1.Grafana, currentState *v1.Service) *v1.Service {
 	reconciled := currentState.DeepCopy()
 	reconciled.Labels = getServiceLabels(cr)
-	reconciled.Annotations = getServiceAnnotations(cr)
+	reconciled.Annotations = getServiceAnnotations(cr, currentState.Annotations)
 	reconciled.Spec.Ports = getServicePorts(cr, currentState)
 	reconciled.Spec.Type = getServiceType(cr)
 	return reconciled

--- a/pkg/controller/model/grafanaServiceAccount.go
+++ b/pkg/controller/model/grafanaServiceAccount.go
@@ -16,11 +16,11 @@ func getServiceAccountLabels(cr *v1alpha1.Grafana) map[string]string {
 	return cr.Spec.ServiceAccount.Labels
 }
 
-func getServiceAccountAnnotations(cr *v1alpha1.Grafana) map[string]string {
+func getServiceAccountAnnotations(cr *v1alpha1.Grafana, existing map[string]string) map[string]string {
 	if cr.Spec.ServiceAccount == nil {
-		return nil
+		return existing
 	}
-	return cr.Spec.ServiceAccount.Annotations
+	return MergeAnnotations(cr.Spec.ServiceAccount.Annotations, existing)
 }
 
 func GrafanaServiceAccount(cr *v1alpha1.Grafana) *v1.ServiceAccount {
@@ -29,7 +29,7 @@ func GrafanaServiceAccount(cr *v1alpha1.Grafana) *v1.ServiceAccount {
 			Name:        GrafanaServiceAccountName,
 			Namespace:   cr.Namespace,
 			Labels:      getServiceAccountLabels(cr),
-			Annotations: getServiceAccountAnnotations(cr),
+			Annotations: getServiceAccountAnnotations(cr, nil),
 		},
 	}
 }
@@ -44,6 +44,6 @@ func GrafanaServiceAccountSelector(cr *v1alpha1.Grafana) client.ObjectKey {
 func GrafanaServiceAccountReconciled(cr *v1alpha1.Grafana, currentState *v1.ServiceAccount) *v1.ServiceAccount {
 	reconciled := currentState.DeepCopy()
 	reconciled.Labels = getServiceAccountLabels(cr)
-	reconciled.Annotations = getServiceAccountAnnotations(cr)
+	reconciled.Annotations = getServiceAccountAnnotations(cr, currentState.Annotations)
 	return reconciled
 }

--- a/pkg/controller/model/utils.go
+++ b/pkg/controller/model/utils.go
@@ -1,6 +1,8 @@
 package model
 
-import "math/rand"
+import (
+	"math/rand"
+)
 
 var letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 
@@ -10,4 +12,15 @@ func RandStringRunes(n int) string {
 		b[i] = letterRunes[rand.Intn(len(letterRunes))]
 	}
 	return string(b)
+}
+
+func MergeAnnotations(requested map[string]string, existing map[string]string) map[string]string {
+	if existing == nil {
+		return requested
+	}
+
+	for k, v := range requested {
+		existing[k] = v
+	}
+	return existing
 }


### PR DESCRIPTION
fixes #127 

Merge annotations with previously existing ones instead of overwriting them. This prevents an infinite loop of reconciliations where OpenShift adds an annotation to be removed by the Operator to be added by OpenShift...

One problem with this is that removing annotations by removing them from the CR doesn't work anymore: you have to remove them from the CR *and* the resource now.