### PR TITLE
openshift-monitoring-update-prometheus-authentication.yaml - init add

### DIFF
--- a/deploy/ansible/README.md
+++ b/deploy/ansible/README.md
@@ -176,6 +176,65 @@ ansible-playbook grafana-operator-cluster-dashboards-scan.yaml \
   -e grafana_operator_install=false
 ```
 
+## openshift-monitoring-update-prometheus-authentication.yaml
+
+Playbook for updateing the authentication for prometehus so as to create accounts for other dashbaords to consume the data prometheus data through the proxy.
+
+### Required K8s Permisions
+These permissions are reuqied by the K8s user who runs this playbook. Typically this would be a cluster administrator.
+
+* edit access to the `openshift-monitoring` project
+
+### Parameters
+
+| Parameter                   | Choices / **Defaults** | Comments
+|-----------------------------|------------------------|---------
+| k8s\_host                   |                        | K8s API to run this playbook against
+| k8s\_validate\_certs        | **True** / False       | Whether to validate K8s API certificate
+| k8s\_api\_key               |                        | K8s API token to authenticate with. Mutually exclusive with `k8s_username` and `k8s_password`.
+| k8s\_username               |                        | K8s username to authenticate with. Mutually exclusive with `k8s_api_key`.
+| k8s\_password               |                        | K8s password to authenticate with. Mutually exclusive with `k8s_api_key`.
+| prometheus\_htpasswd\_users |                        | Array of hashes of user names and passwords to add or remove from the prometheus authentication list. Expected hash keys are `name`, `password`, and optionally `state` with value of `present` or `absent` with a default of `present`.
+
+#### prometheus\_htpasswd\_users
+YAML example
+```yaml
+prometheus_htpasswd_users:
+  - name: custom-monitoring
+    password: secret
+  - name: custom-monitoring-old
+    password: secret
+    state: absent
+```
+
+JSON example
+```json
+'[{"name":"custom-monitoring","password":"secret"},{"name":"custom-monitoring-old","password":"secret","state":"absent"}]'
+```
+
+### Examples
+These are all "one lineer" examples. If following "true" "git-ops" principles recomended you make an inventory file and group\_vars or host\_vars file with the parameters specified there.
+
+### Add new prometheus user
+```
+ansible-playbook deploy/ansible/openshift-monitoring-expose-prometheus.yaml \
+  -i deploy/ansible/localhost.ini \
+  -e k8s_host=https://ocp.example.xyz \
+  -e k8s_username=admin1 \
+  -e k8s_password=secret \
+  -e prometheus_htpasswd_users='[{"name":"custom-monitoring","password":"secret"}]'
+```
+
+### Remove prometheus user
+```
+ansible-playbook deploy/ansible/openshift-monitoring-expose-prometheus.yaml \
+  -i deploy/ansible/localhost.ini \
+  -e k8s_host=https://ocp.example.xyz \
+  -e k8s_username=admin1 \
+  -e k8s_password=secret \
+  -e prometheus_htpasswd_users='[{"name":"custom-monitoring","password":"secret","state":"absent"}]'
+```
+
 # Tested With
 These are the versions these playbooks have been tested with. This does not mean this wont work with other versions this is simply known working versions.
 

--- a/deploy/ansible/localhost.ini
+++ b/deploy/ansible/localhost.ini
@@ -1,0 +1,1 @@
+localhost ansible_connection=local ansible_python_interpreter="{{ansible_playbook_python}}"

--- a/deploy/ansible/openshift-monitoring-update-prometheus-authentication.yaml
+++ b/deploy/ansible/openshift-monitoring-update-prometheus-authentication.yaml
@@ -1,0 +1,143 @@
+---
+- name: OpenShift Monitoring | Update Prometheus Authentication
+  hosts: all
+  module_defaults:
+    group/k8s:
+      host: "{{ k8s_host }}"
+      validate_certs: "{{ k8s_validate_certs | default(true) }}"
+  vars:
+    prometheus_namespace: "openshift-monitoring"
+    prometheus_statefulset: "prometheus-k8s"
+    prometheus_htpasswd_secret: "prometheus-k8s-htpasswd"
+  tasks:
+  - name: OpenShift Monitoring | Update Prometheus Authentication | Params validation | k8s auth
+    fail:
+      msg: "Either k8s_api_key or k8s_username and k8s_password must be specified"
+    when: ((k8s_api_key is not defined) and (k8s_username is not defined) and (k8s_password is not defined)) or
+          ((k8s_api_key is defined) and ((k8s_username is defined) or (k8s_password is defined)))
+
+  - name: OpenShift Monitoring | Update Prometheus Authentication | Params defaults
+    set_fact:
+      openshift_monitoring_expose_prometheus: "{{ openshift_monitoring_expose_prometheus | default(true) }}"
+
+  - name: OpenShift Monitoring | Update Prometheus Authentication | Private params
+    set_fact:
+      _k8s_resources_state: "{{ (openshift_monitoring_expose_prometheus | bool) | ternary('present', 'absent') }}"
+      _k8s_resources_task_title: "{{ (openshift_monitoring_expose_prometheus | bool) | ternary('Create', 'Delete') }}"
+
+  - block:
+    - block:
+      - name: OpenShift Monitoring | Update Prometheus Authentication | Get K8s access token
+        k8s_auth:
+          username: "{{ k8s_username }}"
+          password: "{{ k8s_password }}"
+        register: k8s_auth_results
+
+      - name: OpenShift Monitoring | Update Prometheus Authentication | Set k8s_api_key
+        set_fact:
+          k8s_api_key: "{{ k8s_auth_results.k8s_auth.api_key }}"
+      when: (k8s_api_key is not defined) and ((k8s_username is defined) and (k8s_password is defined))
+
+    - block:
+      - name: OpenShift Monitoring | Update Prometheus Authentication | Get prometheus StatefulSet info
+        k8s_info:
+          kind: StatefulSet
+          name: "{{ prometheus_statefulset }}"
+          namespace: "{{ prometheus_namespace }}"
+          api_key: "{{ k8s_api_key }}"
+        register: prometheus_k8s_info
+
+      - name: OpenShift Monitoring | Update Prometheus Authentication | Get existing prometheus-k8s-htpasswd secret
+        k8s_facts:
+          kind: Secret
+          api_version: v1
+          name: prometheus-k8s-htpasswd
+          namespace: openshift-monitoring
+        register: prometheus_k8s_htpasswd_data
+
+      - name: OpenShift Monitoring | Update Prometheus Authentication | Get existing prometheus-k8s-htpasswd auth value
+        set_fact:
+          prometheus_k8s_htpasswd_data_auth: "{{ prometheus_k8s_htpasswd_data.resources[0]['data']['auth'] | b64decode }}"
+
+      - name: OpenShift Monitoring | Update Prometheus Authentication | Create temparary htpasswd file
+        tempfile:
+          state: file
+          suffix: prometheus-k8s-htpasswd
+        changed_when: False
+        register: prometheus_k8s_htpasswd_tempfile
+
+      - name: OpenShift Monitoring | Update Prometheus Authentication | Copy prometheus_k8s_htpasswd_data into temparary htpasswd file
+        copy:
+          content: "{{ prometheus_k8s_htpasswd_data_auth }}"
+          dest: "{{ prometheus_k8s_htpasswd_tempfile.path }}"
+        changed_when: False
+
+      # TODO: loop var
+      - name: OpenShift Monitoring | Update Prometheus Authentication | Add usernames and passwords to temp htpasswd file
+        htpasswd:
+          path: "{{ prometheus_k8s_htpasswd_tempfile.path }}"
+          state: "{{ item.state | default('present') }}"
+          name: "{{ item.name }}"
+          password: "{{ item.password }}"
+          crypt_scheme: ldap_sha1
+        no_log: true
+        register: htpasswd_result
+        loop: "{{ prometheus_htpasswd_users }}"
+
+      - block:
+        - name: OpenShift Monitoring | Update Prometheus Authentication | Get updated htpasswd file contents
+          slurp:
+            src: "{{ prometheus_k8s_htpasswd_tempfile.path }}"
+          register: prometheus_k8s_htpasswd_new
+
+        - name: OpenShift Monitoring | Update Prometheus Authentication | Update prometheus-k8s-htpasswd secret
+          k8s:
+            kind: Secret
+            name: "{{ prometheus_htpasswd_secret }}"
+            namespace: "{{ prometheus_namespace }}"
+            resource_definition:
+              data:
+                auth: "{{ prometheus_k8s_htpasswd_new.content }}"
+
+        # NOTE: this is a super hack to force a rolling update since there is no k8s_rollout module (https://github.com/ansible/ansible/issues/52046)
+        - name: OpenShift Monitoring | Update Prometheus Authentication | Patch prometheus StatefulSet to force rolling update
+          k8s:
+            kind: StatefulSet
+            name: "{{ prometheus_statefulset }}"
+            namespace: "{{ prometheus_namespace }}"
+            api_key: "{{ k8s_api_key }}"
+            resource_definition:
+              spec:
+                template:
+                  spec:
+                    containers:
+                      - name: prometheus
+                        env:
+                        - name: LAST_UPDATE_OF_PROMETHEUS_K8S_HTPASSWD_SECRET_BY_ANSBILE
+                          value: "{{ ansible_date_time.iso8601 }}"
+
+        - name: OpenShift Monitoring | Update Prometheus Authentication | wait for all pods in prometheus StatefulSet to be updated
+          k8s_info:
+            kind: StatefulSet
+            name: "{{ prometheus_statefulset }}"
+            namespace: "{{ prometheus_namespace }}"
+            api_key: "{{ k8s_api_key }}"
+          register: prometheus_k8s_info
+          until: (prometheus_k8s_info['resources'][0] | json_query('status.currentRevision') ) == (prometheus_k8s_info['resources'][0] | json_query('status.updateRevision') )
+          delay: 2
+          retries: 60
+        when: htpasswd_result is changed
+
+    always:
+    - name: OpenShift Monitoring | Update Prometheus Authentication | Revoke K8s access token
+      k8s_auth:
+        state: absent
+        api_key: "{{ k8s_api_key }}"
+      when: ((k8s_username is defined) and (k8s_password is defined))
+
+    - name: OpenShift Monitoring | Update Prometheus Authentication | remove temporary htpasswd file
+      file:
+        path: "{{ prometheus_k8s_htpasswd_tempfile.path }}"
+        state: absent
+      changed_when: False
+      when: prometheus_k8s_htpasswd_tempfile.path is defined


### PR DESCRIPTION
This isn't strictly Grafana specific but is "needed" to be able to attach Grafana to Prometheus running in OpenShift. If you don't think it belongs here I will put it in https://github.com/redhat-cop/openshift-toolkit.

If you think it belongs here I will also update the documentation but if decide not to put this here may still put in a PR here to link over to where it ends up since it will be a common enough use case I presume that it would be helpful for people.