### PR TITLE
Add option to load dashboard json from a ConfigMap

### DIFF
--- a/deploy/examples/dashboards/DashboardFromConfigMap.yaml
+++ b/deploy/examples/dashboards/DashboardFromConfigMap.yaml
@@ -1,0 +1,47 @@
+apiVersion: integreatly.org/v1alpha1
+kind: GrafanaDashboard
+metadata:
+  name: grafana-dashboard-from-config-map
+  labels:
+    app: grafana
+spec:
+  name: grafana-dashboard-from-config-map.json
+  configMapRef:
+    name: simple-dashboard
+    key: foo
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: simple-dashboard
+data:
+  foo: |-
+    {
+      "id": null,
+      "title": "Simple Dashboard",
+      "tags": [],
+      "style": "dark",
+      "timezone": "browser",
+      "editable": true,
+      "hideControls": false,
+      "graphTooltip": 1,
+      "panels": [],
+      "time": {
+        "from": "now-6h",
+        "to": "now"
+      },
+      "timepicker": {
+        "time_options": [],
+        "refresh_intervals": []
+      },
+      "templating": {
+        "list": []
+      },
+      "annotations": {
+        "list": []
+      },
+      "refresh": "5s",
+      "schemaVersion": 17,
+      "version": 0,
+      "links": []
+    }

--- a/deploy/roles/role.yaml
+++ b/deploy/roles/role.yaml
@@ -14,6 +14,7 @@ rules:
       - configmaps
       - secrets
       - serviceaccounts
+      - configmaps
     verbs:
       - get
       - list

--- a/pkg/apis/integreatly/v1alpha1/grafanadashboard_types.go
+++ b/pkg/apis/integreatly/v1alpha1/grafanadashboard_types.go
@@ -1,6 +1,7 @@
 package v1alpha1
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -13,11 +14,12 @@ const GrafanaDashboardKind = "GrafanaDashboard"
 type GrafanaDashboardSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
-	Json        string                       `json:"json"`
-	Name        string                       `json:"name"`
-	Plugins     PluginList                   `json:"plugins,omitempty"`
-	Url         string                       `json:"url,omitempty"`
-	Datasources []GrafanaDashboardDatasource `json:"datasources,omitempty"`
+	Json         string                       `json:"json"`
+	Name         string                       `json:"name"`
+	Plugins      PluginList                   `json:"plugins,omitempty"`
+	Url          string                       `json:"url,omitempty"`
+	ConfigMapRef *corev1.ConfigMapKeySelector `json:"configMapRef,omitempty"`
+	Datasources  []GrafanaDashboardDatasource `json:"datasources,omitempty"`
 }
 
 type GrafanaDashboardDatasource struct {

--- a/pkg/apis/integreatly/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/integreatly/v1alpha1/zz_generated.deepcopy.go
@@ -1163,6 +1163,11 @@ func (in *GrafanaDashboardSpec) DeepCopyInto(out *GrafanaDashboardSpec) {
 		*out = make(PluginList, len(*in))
 		copy(*out, *in)
 	}
+	if in.ConfigMapRef != nil {
+		in, out := &in.ConfigMapRef, &out.ConfigMapRef
+		*out = new(v1.ConfigMapKeySelector)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Datasources != nil {
 		in, out := &in.Datasources, &out.Datasources
 		*out = make([]GrafanaDashboardDatasource, len(*in))

--- a/pkg/controller/grafanadashboard/dashboard_controller.go
+++ b/pkg/controller/grafanadashboard/dashboard_controller.go
@@ -207,11 +207,11 @@ func (r *ReconcileGrafanaDashboard) reconcileDashboards(request reconcile.Reques
 		// Process the dashboard. Use the known hash of an existing dashboard
 		// to determine if an update is required
 		knownHash := findHash(&dashboard)
-		pipeline := NewDashboardPipeline(&dashboard, r.state.FixAnnotations, r.state.FixHeights)
+		pipeline := NewDashboardPipeline(&r.client, &dashboard, r.state.FixAnnotations, r.state.FixHeights)
 		processed, err := pipeline.ProcessDashboard(knownHash)
 
 		if err != nil {
-			log.Info(fmt.Sprintf("cannot process dashboard %v/%v", dashboard.Namespace, dashboard.Name))
+			log.Error(err, fmt.Sprintf("cannot process dashboard %v/%v", dashboard.Namespace, dashboard.Name))
 			r.manageError(&dashboard, err)
 			continue
 		}

--- a/pkg/controller/grafanadashboard/dashboard_controller.go
+++ b/pkg/controller/grafanadashboard/dashboard_controller.go
@@ -207,7 +207,7 @@ func (r *ReconcileGrafanaDashboard) reconcileDashboards(request reconcile.Reques
 		// Process the dashboard. Use the known hash of an existing dashboard
 		// to determine if an update is required
 		knownHash := findHash(&dashboard)
-		pipeline := NewDashboardPipeline(&r.client, &dashboard, r.state.FixAnnotations, r.state.FixHeights)
+		pipeline := NewDashboardPipeline(r.client, &dashboard, r.state.FixAnnotations, r.state.FixHeights)
 		processed, err := pipeline.ProcessDashboard(knownHash)
 
 		if err != nil {

--- a/pkg/controller/grafanadashboard/dashboard_pipeline.go
+++ b/pkg/controller/grafanadashboard/dashboard_pipeline.go
@@ -24,7 +24,7 @@ type DashboardPipeline interface {
 }
 
 type DashboardPipelineImpl struct {
-	Client         *client.Client
+	Client         client.Client
 	Dashboard      *v1alpha1.GrafanaDashboard
 	JSON           string
 	Board          map[string]interface{}
@@ -34,7 +34,7 @@ type DashboardPipelineImpl struct {
 	FixHeights     bool
 }
 
-func NewDashboardPipeline(client *client.Client, dashboard *v1alpha1.GrafanaDashboard, fixAnnotations bool, fixHeights bool) DashboardPipeline {
+func NewDashboardPipeline(client client.Client, dashboard *v1alpha1.GrafanaDashboard, fixAnnotations bool, fixHeights bool) DashboardPipeline {
 	return &DashboardPipelineImpl{
 		Client:         client,
 		Dashboard:      dashboard,
@@ -180,7 +180,7 @@ func (r *DashboardPipelineImpl) loadDashboardFromConfigMap() error {
 	objectKey := client.ObjectKey{Name: r.Dashboard.Spec.ConfigMapRef.Name, Namespace: r.Dashboard.Namespace}
 
 	var cm corev1.ConfigMap
-	err := (*r.Client).Get(ctx, objectKey, &cm)
+	err := r.Client.Get(ctx, objectKey, &cm)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Adding the option to load json from a ConfigMap would allow loading of dashboard json in a decoupled manner. Other controllers would in theory be able to fetch or generate json without being aware of the grafana-operator. Additionally every method for fetching json would not have to be implemented in this controllers. 