### PR TITLE
Improvements to 3 0 2

### DIFF
--- a/pkg/controller/grafana/grafana_controller.go
+++ b/pkg/controller/grafana/grafana_controller.go
@@ -216,6 +216,12 @@ func (r *ReconcileGrafana) getGrafanaAdminUrl(cr *grafanav1alpha1.Grafana, state
 
 	// Try the ingress first if on vanilla Kubernetes
 	if state.GrafanaIngress != nil && !preferService {
+		// If provided, use the hostname from the CR
+		if cr.Spec.Ingress != nil && cr.Spec.Ingress.Hostname != "" {
+			return fmt.Sprintf("https://%v", cr.Spec.Ingress.Hostname), nil
+		}
+
+		// Otherwise try to find something suitable, hostname or IP
 		for _, ingress := range state.GrafanaIngress.Status.LoadBalancer.Ingress {
 			if ingress.Hostname != "" {
 				return fmt.Sprintf("https://%v", ingress.Hostname), nil

--- a/pkg/controller/grafanadashboard/dashboard_pipeline.go
+++ b/pkg/controller/grafanadashboard/dashboard_pipeline.go
@@ -75,7 +75,6 @@ func (r *DashboardPipelineImpl) ProcessDashboard(knownHash string) ([]byte, erro
 	if r.Dashboard.Status.Phase == v1alpha1.PhaseReconciling {
 		r.Board["slug"] = r.Dashboard.Status.Slug
 		r.Board["uid"] = r.Dashboard.Status.UID
-		r.Board["id"] = r.Dashboard.Status.ID
 	}
 
 	raw, err := json.Marshal(r.Board)


### PR DESCRIPTION
fix for #136 and #137 

fixes a case where one dashboard could overwrite another if Grafana was restarted (due to plugins) and upon reimport old dashboard IDs (from the status block) were reused.