### PR TITLE
Don't update dashboards

### DIFF
--- a/pkg/controller/grafana/grafana_controller.go
+++ b/pkg/controller/grafana/grafana_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	stdErr "errors"
 	"fmt"
+
 	grafanav1alpha1 "github.com/integr8ly/grafana-operator/v3/pkg/apis/integreatly/v1alpha1"
 	"github.com/integr8ly/grafana-operator/v3/pkg/controller/common"
 	"github.com/integr8ly/grafana-operator/v3/pkg/controller/config"
@@ -253,7 +254,6 @@ func (r *ReconcileGrafana) manageSuccess(cr *grafanav1alpha1.Grafana, state *com
 	if r.config.GetConfigBool(config.ConfigGrafanaDashboardsSynced, false) {
 		cr.Status.InstalledDashboards = r.config.Dashboards
 	} else {
-		r.config.SetDashboards(cr.Status.InstalledDashboards)
 		if r.config.Dashboards == nil {
 			r.config.SetDashboards(make(map[string][]*grafanav1alpha1.GrafanaDashboardRef))
 		}


### PR DESCRIPTION
This commit refer the issue #145
Debug a bit, I saw that if the Dashboard updates the variable in this condition, in dashboard_controller the func reconcileDashboards will not falling in the loop to new/update dashboard, causing a not insert dashboards like mentioned in #145.