### PR TITLE
fix invalid yaml format

### DIFF
--- a/deploy/examples/oauth/session-secret.yaml
+++ b/deploy/examples/oauth/session-secret.yaml
@@ -4,4 +4,4 @@ data:
 kind: Secret
 metadata:
   name: grafana-k8s-proxy
-  type: Opaque
+type: Opaque


### PR DESCRIPTION
This file `session-secret.yaml` have an invalid `Secret` format and can not apply to k8s cluster.

```
root@oauth(master)$ k apply -f session-secret.yaml
error: error validating "session-secret.yaml": error validating data: ValidationError(Secret.metadata): unknown field "type" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta; if you choose to ignore these errors, turn validation off with --validate=false
```