### PR TITLE
Lock added to prevent data race

### DIFF
--- a/pkg/controller/config/controller_config.go
+++ b/pkg/controller/config/controller_config.go
@@ -67,6 +67,8 @@ func (c *ControllerConfig) GetPluginsFor(dashboard *v1alpha1.GrafanaDashboard) v
 
 func (c *ControllerConfig) SetPluginsFor(dashboard *v1alpha1.GrafanaDashboard) {
 	id := c.GetDashboardId(dashboard.Namespace, dashboard.Name)
+	c.Lock()
+	defer c.Unlock()
 	c.Plugins[id] = dashboard.Spec.Plugins
 }
 


### PR DESCRIPTION
## Description
https://issues.redhat.com/browse/INTLY-7215

Using the `--scan-all` flag to watch for dashboards in all namespaces caused a operator to crash due to a data race condition.

## Prerequisites
- Openshift 4 cluster
- Operator-SDK. If possible, use version `0.16.0`, as versions `0.15.1` and `0.17.0` will not work when running the operator locally

## Verification Steps
- `oc login` to you OS4 cluster
- Create a large number of namespaces (70 is recommended) and populate each with a number of dashboards
- Create a new Grafana namespace: `oc new-project grafana`
- Add the following matchExpression to the `deploy/examples/Grafana.yaml` file:
```
    - matchExpressions:
        - {key: app, operator: In, values: [syndesis]}
```
- Deploy Grafana to your cluster: `oc apply -f deploy/examples/Grafana.yaml -n grafana`
- Run the operator, passing in the `--scan-all` flag: `operator-sdk run --local --operator-flags "--scan-all"`
- Allow the operator to run for a few minutes. Confirm that is does not crash with any of the following errors: 

- `fatal error: concurrent map iteration and map write`
- `fatal error concurrent map writes`

- Stop the operator and re-run, making sure again that it runs successfully, without crashing.