### PR TITLE
Support to provide persistent storage for grafana database

### DIFF
--- a/deploy/examples/persistentvolume/Grafana.yaml
+++ b/deploy/examples/persistentvolume/Grafana.yaml
@@ -1,0 +1,22 @@
+apiVersion: integreatly.org/v1alpha1
+kind: Grafana
+metadata:
+  name: example-grafana
+spec:
+  ingress:
+    enabled: True
+  config:
+    log:
+      mode: "console"
+      level: "warn"
+    security:
+      admin_user: "root"
+      admin_password: "secret"
+    auth:
+      disable_login_form: False
+      disable_signout_menu: True
+    auth.anonymous:
+      enabled: True
+  dashboardLabelSelector:
+    - matchExpressions:
+        - {key: app, operator: In, values: [grafana]}

--- a/deploy/examples/persistentvolume/Grafana.yaml
+++ b/deploy/examples/persistentvolume/Grafana.yaml
@@ -5,6 +5,11 @@ metadata:
 spec:
   ingress:
     enabled: True
+  dataStorage:
+    accessModes:
+    - ReadWriteOnce
+    class: {Replace with your StorageClass}
+    size: 10Gi
   config:
     log:
       mode: "console"

--- a/deploy/examples/persistentvolume/README.md
+++ b/deploy/examples/persistentvolume/README.md
@@ -1,0 +1,13 @@
+# Grafana with persistent storage
+
+This example demonstrates how to deploy Grafana with persistent storage.
+
+Grafana uses sqlite database to store user data by default, we can use `PersistentVolume` to persist such user's data.
+
+## Installation
+
+1. Make sure the operator is running, then create the Grafana:
+
+```shell script
+$ kubectl apply -f deploy/examples/persistentvolume
+```

--- a/pkg/apis/integreatly/v1alpha1/grafana_types.go
+++ b/pkg/apis/integreatly/v1alpha1/grafana_types.go
@@ -3,6 +3,7 @@ package v1alpha1
 import (
 	v12 "github.com/openshift/api/route/v1"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -24,6 +25,7 @@ type GrafanaSpec struct {
 	Secrets                []string                 `json:"secrets,omitempty"`
 	ConfigMaps             []string                 `json:"configMaps,omitempty"`
 	Service                *GrafanaService          `json:"service,omitempty"`
+	DataStorage            *GrafanaDataStorage      `json:"dataStorage,omitempty"`
 	Deployment             *GrafanaDeployment       `json:"deployment,omitempty"`
 	Resources              *v1.ResourceRequirements `json:"resources,omitempty"`
 	ServiceAccount         *GrafanaServiceAccount   `json:"serviceAccount,omitempty"`
@@ -49,6 +51,15 @@ type GrafanaService struct {
 	Labels      map[string]string `json:"labels,omitempty"`
 	Type        v1.ServiceType    `json:"type,omitempty"`
 	Ports       []v1.ServicePort  `json:"ports,omitempty"`
+}
+
+// GrafanaDataStorage provides a means to configure the grafana data storage
+type GrafanaDataStorage struct {
+	Annotations map[string]string               `json:"annotations,omitempty"`
+	Labels      map[string]string               `json:"labels,omitempty"`
+	AccessModes []v1.PersistentVolumeAccessMode `json:"accessModes,omitempty"`
+	Size        resource.Quantity               `json:"size"`
+	Class       string                          `json:"class"`
 }
 
 type GrafanaServiceAccount struct {

--- a/pkg/apis/integreatly/v1alpha1/helper.go
+++ b/pkg/apis/integreatly/v1alpha1/helper.go
@@ -1,0 +1,5 @@
+package v1alpha1
+
+func (g *Grafana) UsedPersistentVolume() bool {
+	return g.Spec.DataStorage != nil
+}

--- a/pkg/controller/model/constants.go
+++ b/pkg/controller/model/constants.go
@@ -5,6 +5,7 @@ const (
 	GrafanaVersion                      = "6.5.1"
 	GrafanaServiceAccountName           = "grafana-serviceaccount"
 	GrafanaServiceName                  = "grafana-service"
+	GrafanaDataStorageName              = "grafana-pvc"
 	GrafanaConfigName                   = "grafana-config"
 	GrafanaConfigFileName               = "grafana.ini"
 	GrafanaIngressName                  = "grafana-ingress"

--- a/pkg/controller/model/grafanaDataPvc.go
+++ b/pkg/controller/model/grafanaDataPvc.go
@@ -1,0 +1,62 @@
+package model
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/integr8ly/grafana-operator/v3/pkg/apis/integreatly/v1alpha1"
+)
+
+func getPVCLabels(cr *v1alpha1.Grafana) map[string]string {
+	if cr.Spec.DataStorage == nil {
+		return nil
+	}
+	return cr.Spec.DataStorage.Labels
+}
+
+func getPVCAnnotations(cr *v1alpha1.Grafana, existing map[string]string) map[string]string {
+	if cr.Spec.DataStorage == nil {
+		return existing
+	}
+
+	return MergeAnnotations(cr.Spec.DataStorage.Annotations, existing)
+}
+
+func getPVCSpec(cr *v1alpha1.Grafana) corev1.PersistentVolumeClaimSpec {
+	return corev1.PersistentVolumeClaimSpec{
+		AccessModes: cr.Spec.DataStorage.AccessModes,
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceStorage: cr.Spec.DataStorage.Size,
+			},
+		},
+		StorageClassName: &cr.Spec.DataStorage.Class,
+	}
+}
+
+func GrafanaDataPVC(cr *v1alpha1.Grafana) *corev1.PersistentVolumeClaim {
+	return &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        GrafanaDataStorageName,
+			Namespace:   cr.Namespace,
+			Labels:      getPVCLabels(cr),
+			Annotations: getPVCAnnotations(cr, nil),
+		},
+		Spec: getPVCSpec(cr),
+	}
+}
+
+func GrafanaPVCReconciled(cr *v1alpha1.Grafana, currentState *corev1.PersistentVolumeClaim) *corev1.PersistentVolumeClaim {
+	reconciled := currentState.DeepCopy()
+	reconciled.Labels = getPVCLabels(cr)
+	reconciled.Annotations = getPVCAnnotations(cr, currentState.Annotations)
+	return reconciled
+}
+
+func GrafanaDataStorageSelector(cr *v1alpha1.Grafana) client.ObjectKey {
+	return client.ObjectKey{
+		Namespace: cr.Namespace,
+		Name:      GrafanaDataStorageName,
+	}
+}

--- a/pkg/controller/model/grafanaDeployment.go
+++ b/pkg/controller/model/grafanaDeployment.go
@@ -149,12 +149,23 @@ func getVolumes(cr *v1alpha1.Grafana) []v13.Volume {
 	})
 
 	// Data volume
-	volumes = append(volumes, v13.Volume{
-		Name: GrafanaDataVolumeName,
-		VolumeSource: v13.VolumeSource{
-			EmptyDir: &v13.EmptyDirVolumeSource{},
-		},
-	})
+	if cr.UsedPersistentVolume() {
+		volumes = append(volumes, v13.Volume{
+			Name: GrafanaDataVolumeName,
+			VolumeSource: v13.VolumeSource{
+				PersistentVolumeClaim: &v13.PersistentVolumeClaimVolumeSource{
+					ClaimName: GrafanaDataStorageName,
+				},
+			},
+		})
+	} else {
+		volumes = append(volumes, v13.Volume{
+			Name: GrafanaDataVolumeName,
+			VolumeSource: v13.VolumeSource{
+				EmptyDir: &v13.EmptyDirVolumeSource{},
+			},
+		})
+	}
 
 	// Volume to store the plugins
 	volumes = append(volumes, v13.Volume{


### PR DESCRIPTION
Now in order to persist the data, we need to deploy a mysql or postgres database, wait for the database to start, and then config the grafana.spec.database field. 
I think if the operator can provide the ability to customize the persistent storage, it will be greatly simplified.
This PR refer the issue #147.