### PR TITLE
Intly 7239 grafana operator should watch rhmi namespaces for crs

### DIFF
--- a/deploy/cluster_roles/README.md
+++ b/deploy/cluster_roles/README.md
@@ -2,7 +2,7 @@
 
 ## Grant Grafana instance RBAC to GrafanaDashboard definitions in other projects/namespaces
 
-By default a Grafana instance deployed by the Grafana Operator will only read GrafanaDashboard custom resources from the namespace/project that the Grafana instance is deployed in. If specifing the `--scan-all` or `--namespaces` flags then the ServiceAccount that Grafana is running as needs view access to the GrafanaDashboard resources in other namespaces. To grant those permissions the following ClusterRole and ClusterRoleBinding need to be deployed.
+By default a Grafana instance deployed by the Grafana Operator will only read GrafanaDashboard custom resources from the namespace/project that the Grafana instance is deployed in. If specifing the `--scan-all` or `--namespaces` flags or if your using `dashboardNamespaceSelector`, then the ServiceAccount that Grafana is running as needs view access to the GrafanaDashboard resources in other namespaces. To grant those permissions the following ClusterRole and ClusterRoleBinding need to be deployed.
 
 Create the `ClusterRole`
 ```

--- a/deploy/cluster_roles/cluster_role_grafana_operator.yaml
+++ b/deploy/cluster_roles/cluster_role_grafana_operator.yaml
@@ -9,3 +9,9 @@ rules:
       - grafanadashboards
       - grafanadashboards/status
     verbs: ['get', 'list', 'update', 'watch']
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs: ['get', 'list', 'watch']
+

--- a/deploy/crds/Grafana.yaml
+++ b/deploy/crds/Grafana.yaml
@@ -135,6 +135,3 @@ spec:
               items:
                 type: object
                 description: Label selector or match expressions
-             dashboardNamespaceSelector:
-              type: object
-              

--- a/deploy/crds/Grafana.yaml
+++ b/deploy/crds/Grafana.yaml
@@ -135,3 +135,6 @@ spec:
               items:
                 type: object
                 description: Label selector or match expressions
+             dashboardNamespaceSelector:
+              type: object
+              

--- a/documentation/multi_namespace_support.md
+++ b/documentation/multi_namespace_support.md
@@ -15,7 +15,7 @@ Set the `--scan-all` flag to watch for dashboards in all namespaces. Cluster wid
 You can provide a comma separated list of watch namespaces using the `--namespaces` flag. The format is `--namespaces=<NS_1,NS_2,...,NS_N>`, for example: `--namespaces=grafana,dashboards,example_namespace`.
 The same cluster wide permissions as for watching all namespaces are required.
 
-*NOTE*: `--scan-all` and `--namespaces` are mutually exclusive. You can only use one at a time.
+***NOTE***: `--scan-all` and `--namespaces` are mutually exclusive. You can only use one at a time.
 
 ### 2. **dashboardNamespaceSelector**
 You can also watch for dashboards in certain namespaces by using the dashboardNamespaceSelector in the Grafana CR. This watches for dashboards only in the Namespaces that have the specified namespace label. The format to specify labels is 
@@ -24,3 +24,4 @@ dashboardNamespaceSelector:
     matchLabels:
       key: value
 ```
+***NOTE***: `--namespaces` and the `dashboardNamespaceSelector` are mutually exclusive and shoudlnt be used together

--- a/documentation/multi_namespace_support.md
+++ b/documentation/multi_namespace_support.md
@@ -11,7 +11,16 @@ Set the `--scan-all` flag to watch for dashboards in all namespaces. Cluster wid
 
 ## Watching for dashboards in some namespaces
 
+### 1. **namespace operator flag**
 You can provide a comma separated list of watch namespaces using the `--namespaces` flag. The format is `--namespaces=<NS_1,NS_2,...,NS_N>`, for example: `--namespaces=grafana,dashboards,example_namespace`.
 The same cluster wide permissions as for watching all namespaces are required.
 
 *NOTE*: `--scan-all` and `--namespaces` are mutually exclusive. You can only use one at a time.
+
+### 2. **dashboardNamespaceSelector**
+You can also watch for dashboards in certain namespaces by using the dashboardNamespaceSelector in the Grafana CR. This watches for dashboards only in the Namespaces that have the specified namespace label. The format to specify labels is 
+```
+dashboardNamespaceSelector:
+    matchLabels:
+      key: value
+```

--- a/pkg/apis/integreatly/v1alpha1/grafana_types.go
+++ b/pkg/apis/integreatly/v1alpha1/grafana_types.go
@@ -17,19 +17,19 @@ var (
 // GrafanaSpec defines the desired state of Grafana
 // +k8s:openapi-gen=true
 type GrafanaSpec struct {
-	Config                 		GrafanaConfig            	`json:"config"`
-	Containers             		[]v1.Container           	`json:"containers,omitempty"`
-	DashboardLabelSelector 		[]*metav1.LabelSelector  	`json:"dashboardLabelSelector,omitempty"`
-	Ingress                		*GrafanaIngress          	`json:"ingress,omitempty"`
-	Secrets                		[]string                	`json:"secrets,omitempty"`
-	ConfigMaps             		[]string                 	`json:"configMaps,omitempty"`
-	Service                		*GrafanaService          	`json:"service,omitempty"`
-	Deployment             		*GrafanaDeployment       	`json:"deployment,omitempty"`
-	Resources              		*v1.ResourceRequirements 	`json:"resources,omitempty"`
-	ServiceAccount         		*GrafanaServiceAccount   	`json:"serviceAccount,omitempty"`
-	Client                 		*GrafanaClient           	`json:"client,omitempty"`
-	Compat                 		*GrafanaCompat          	`json:"compat"`
-	DashboardNamespaceSelector  *metav1.LabelSelector  		`json:"dashboardNamespaceSelector,omitempty"`
+	Config                     GrafanaConfig            `json:"config"`
+	Containers                 []v1.Container           `json:"containers,omitempty"`
+	DashboardLabelSelector     []*metav1.LabelSelector  `json:"dashboardLabelSelector,omitempty"`
+	Ingress                    *GrafanaIngress          `json:"ingress,omitempty"`
+	Secrets                    []string                 `json:"secrets,omitempty"`
+	ConfigMaps                 []string                 `json:"configMaps,omitempty"`
+	Service                    *GrafanaService          `json:"service,omitempty"`
+	Deployment                 *GrafanaDeployment       `json:"deployment,omitempty"`
+	Resources                  *v1.ResourceRequirements `json:"resources,omitempty"`
+	ServiceAccount             *GrafanaServiceAccount   `json:"serviceAccount,omitempty"`
+	Client                     *GrafanaClient           `json:"client,omitempty"`
+	Compat                     *GrafanaCompat           `json:"compat"`
+	DashboardNamespaceSelector *metav1.LabelSelector    `json:"dashboardNamespaceSelector,omitempty"`
 }
 
 // Backwards compatibility switches

--- a/pkg/apis/integreatly/v1alpha1/grafana_types.go
+++ b/pkg/apis/integreatly/v1alpha1/grafana_types.go
@@ -17,18 +17,19 @@ var (
 // GrafanaSpec defines the desired state of Grafana
 // +k8s:openapi-gen=true
 type GrafanaSpec struct {
-	Config                 GrafanaConfig            `json:"config"`
-	Containers             []v1.Container           `json:"containers,omitempty"`
-	DashboardLabelSelector []*metav1.LabelSelector  `json:"dashboardLabelSelector,omitempty"`
-	Ingress                *GrafanaIngress          `json:"ingress,omitempty"`
-	Secrets                []string                 `json:"secrets,omitempty"`
-	ConfigMaps             []string                 `json:"configMaps,omitempty"`
-	Service                *GrafanaService          `json:"service,omitempty"`
-	Deployment             *GrafanaDeployment       `json:"deployment,omitempty"`
-	Resources              *v1.ResourceRequirements `json:"resources,omitempty"`
-	ServiceAccount         *GrafanaServiceAccount   `json:"serviceAccount,omitempty"`
-	Client                 *GrafanaClient           `json:"client,omitempty"`
-	Compat                 *GrafanaCompat           `json:"compat"`
+	Config                 		GrafanaConfig            	`json:"config"`
+	Containers             		[]v1.Container           	`json:"containers,omitempty"`
+	DashboardLabelSelector 		[]*metav1.LabelSelector  	`json:"dashboardLabelSelector,omitempty"`
+	Ingress                		*GrafanaIngress          	`json:"ingress,omitempty"`
+	Secrets                		[]string                	`json:"secrets,omitempty"`
+	ConfigMaps             		[]string                 	`json:"configMaps,omitempty"`
+	Service                		*GrafanaService          	`json:"service,omitempty"`
+	Deployment             		*GrafanaDeployment       	`json:"deployment,omitempty"`
+	Resources              		*v1.ResourceRequirements 	`json:"resources,omitempty"`
+	ServiceAccount         		*GrafanaServiceAccount   	`json:"serviceAccount,omitempty"`
+	Client                 		*GrafanaClient           	`json:"client,omitempty"`
+	Compat                 		*GrafanaCompat          	`json:"compat"`
+	DashboardNamespaceSelector  *metav1.LabelSelector  		`json:"dashboardNamespaceSelector,omitempty"`
 }
 
 // Backwards compatibility switches

--- a/pkg/apis/integreatly/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/integreatly/v1alpha1/zz_generated.deepcopy.go
@@ -1631,6 +1631,11 @@ func (in *GrafanaSpec) DeepCopyInto(out *GrafanaSpec) {
 		*out = new(GrafanaCompat)
 		**out = **in
 	}
+	if in.DashboardNamespaceSelector != nil {
+		in, out := &in.DashboardNamespaceSelector, &out.DashboardNamespaceSelector
+		*out = new(metav1.LabelSelector)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/pkg/apis/integreatly/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/integreatly/v1alpha1/zz_generated.openapi.go
@@ -30,14 +30,14 @@ func schema_pkg_apis_integreatly_v1alpha1_Grafana(ref common.ReferenceCallback) 
 				Properties: map[string]spec.Schema{
 					"kind": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+							Description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"apiVersion": {
 						SchemaProps: spec.SchemaProps{
-							Description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+							Description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -74,14 +74,14 @@ func schema_pkg_apis_integreatly_v1alpha1_GrafanaDashboard(ref common.ReferenceC
 				Properties: map[string]spec.Schema{
 					"kind": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+							Description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"apiVersion": {
 						SchemaProps: spec.SchemaProps{
-							Description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+							Description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -118,14 +118,14 @@ func schema_pkg_apis_integreatly_v1alpha1_GrafanaDataSource(ref common.Reference
 				Properties: map[string]spec.Schema{
 					"kind": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+							Description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"apiVersion": {
 						SchemaProps: spec.SchemaProps{
-							Description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+							Description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -306,12 +306,22 @@ func schema_pkg_apis_integreatly_v1alpha1_GrafanaSpec(ref common.ReferenceCallba
 							Ref: ref("./pkg/apis/integreatly/v1alpha1.GrafanaClient"),
 						},
 					},
+					"compat": {
+						SchemaProps: spec.SchemaProps{
+							Ref: ref("./pkg/apis/integreatly/v1alpha1.GrafanaCompat"),
+						},
+					},
+					"dashboardNamespaceSelector": {
+						SchemaProps: spec.SchemaProps{
+							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.LabelSelector"),
+						},
+					},
 				},
-				Required: []string{"config"},
+				Required: []string{"config", "compat"},
 			},
 		},
 		Dependencies: []string{
-			"./pkg/apis/integreatly/v1alpha1.GrafanaClient", "./pkg/apis/integreatly/v1alpha1.GrafanaConfig", "./pkg/apis/integreatly/v1alpha1.GrafanaDeployment", "./pkg/apis/integreatly/v1alpha1.GrafanaIngress", "./pkg/apis/integreatly/v1alpha1.GrafanaService", "./pkg/apis/integreatly/v1alpha1.GrafanaServiceAccount", "k8s.io/api/core/v1.Container", "k8s.io/api/core/v1.ResourceRequirements", "k8s.io/apimachinery/pkg/apis/meta/v1.LabelSelector"},
+			"./pkg/apis/integreatly/v1alpha1.GrafanaClient", "./pkg/apis/integreatly/v1alpha1.GrafanaCompat", "./pkg/apis/integreatly/v1alpha1.GrafanaConfig", "./pkg/apis/integreatly/v1alpha1.GrafanaDeployment", "./pkg/apis/integreatly/v1alpha1.GrafanaIngress", "./pkg/apis/integreatly/v1alpha1.GrafanaService", "./pkg/apis/integreatly/v1alpha1.GrafanaServiceAccount", "k8s.io/api/core/v1.Container", "k8s.io/api/core/v1.ResourceRequirements", "k8s.io/apimachinery/pkg/apis/meta/v1.LabelSelector"},
 	}
 }
 
@@ -378,20 +388,8 @@ func schema_pkg_apis_integreatly_v1alpha1_GrafanaStatus(ref common.ReferenceCall
 							},
 						},
 					},
-					"adminUser": {
-						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
-						},
-					},
-					"adminPassword": {
-						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
-						},
-					},
 				},
-				Required: []string{"phase", "message", "dashboards", "installedPlugins", "failedPlugins", "adminUser", "adminPassword"},
+				Required: []string{"phase", "message", "dashboards", "installedPlugins", "failedPlugins"},
 			},
 		},
 		Dependencies: []string{

--- a/pkg/controller/common/controllerState.go
+++ b/pkg/controller/common/controllerState.go
@@ -5,12 +5,13 @@ import v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 var ControllerEvents = make(chan ControllerState, 1)
 
 type ControllerState struct {
-	DashboardSelectors []*v1.LabelSelector
-	AdminUsername      string
-	AdminPassword      string
-	AdminUrl           string
-	GrafanaReady       bool
-	ClientTimeout      int
-	FixAnnotations     bool
-	FixHeights         bool
+	DashboardSelectors         []*v1.LabelSelector
+	DashboardNamespaceSelector *v1.LabelSelector
+	AdminUsername              string
+	AdminPassword              string
+	AdminUrl                   string
+	GrafanaReady               bool
+	ClientTimeout              int
+	FixAnnotations             bool
+	FixHeights                 bool
 }

--- a/pkg/controller/grafana/grafana_controller.go
+++ b/pkg/controller/grafana/grafana_controller.go
@@ -288,14 +288,15 @@ func (r *ReconcileGrafana) manageSuccess(cr *grafanav1alpha1.Grafana, state *com
 
 	// Publish controller state
 	controllerState := common.ControllerState{
-		DashboardSelectors: cr.Spec.DashboardLabelSelector,
-		AdminUsername:      string(state.AdminSecret.Data[model.GrafanaAdminUserEnvVar]),
-		AdminPassword:      string(state.AdminSecret.Data[model.GrafanaAdminPasswordEnvVar]),
-		AdminUrl:           url,
-		GrafanaReady:       true,
-		ClientTimeout:      DefaultClientTimeoutSeconds,
-		FixAnnotations:     fixAnnotations,
-		FixHeights:         fixHeights,
+		DashboardSelectors:         cr.Spec.DashboardLabelSelector,
+		DashboardNamespaceSelector: cr.Spec.DashboardNamespaceSelector,
+		AdminUsername:              string(state.AdminSecret.Data[model.GrafanaAdminUserEnvVar]),
+		AdminPassword:              string(state.AdminSecret.Data[model.GrafanaAdminPasswordEnvVar]),
+		AdminUrl:                   url,
+		GrafanaReady:               true,
+		ClientTimeout:              DefaultClientTimeoutSeconds,
+		FixAnnotations:             fixAnnotations,
+		FixHeights:                 fixHeights,
 	}
 
 	if cr.Spec.Client != nil && cr.Spec.Client.TimeoutSeconds != nil {

--- a/pkg/controller/grafanadashboard/dashboard_controller.go
+++ b/pkg/controller/grafanadashboard/dashboard_controller.go
@@ -117,10 +117,13 @@ func (r *ReconcileGrafanaDashboard) Reconcile(request reconcile.Request) (reconc
 	}
 
 	if r.state.DashboardNamespaceSelector != nil {
-
+		 
+		log.Info("hello world Test")
 		matchesNamespaceLabels, err := r.checkNamespaceLabels(request)
-
+		// r.checkNamespaceLabels(request)
 		if err != nil {
+			log.Info("test error")
+			// log.Info(err.Error())
 			return reconcile.Result{Requeue: false}, err
 
 		}
@@ -130,7 +133,9 @@ func (r *ReconcileGrafanaDashboard) Reconcile(request reconcile.Request) (reconc
 		}
 
 	}
+	//return reconcile.Result{Requeue: false},nil
 	
+
 	client, err := r.getClient()
 	if err != nil {
 		return reconcile.Result{RequeueAfter: config.RequeueDelay}, nil
@@ -179,10 +184,12 @@ func (r *ReconcileGrafanaDashboard) checkNamespaceLabels(request reconcile.Reque
 	ns := &v1.Namespace{}
 	err := r.client.Get(r.context, key, ns)
 	if err != nil {
+		log.Info("check test",err.Error())
 		return false, err
 	}
 	selector, err := metav1.LabelSelectorAsSelector(r.state.DashboardNamespaceSelector)
 	if err != nil {
+		// log.Info("check selector", err.Error())
 		return false, err
 	}
 	return selector.Empty() || selector.Matches(labels.Set(ns.Labels)), nil

--- a/pkg/controller/grafanadashboard/dashboard_controller.go
+++ b/pkg/controller/grafanadashboard/dashboard_controller.go
@@ -119,16 +119,18 @@ func (r *ReconcileGrafanaDashboard) Reconcile(request reconcile.Request) (reconc
 	if r.state.DashboardNamespaceSelector != nil {
 
 		matchesNamespaceLabels, err := r.checkNamespaceLabels(request)
-		if matchesNamespaceLabels == false {
-			log.Info("Dashboard skipped as labels do not match", matchesNamespaceLabels)
-			return reconcile.Result{Requeue: false}, nil
-		}
+
 		if err != nil {
 			return reconcile.Result{Requeue: false}, err
 
 		}
-	}
+		if matchesNamespaceLabels == false {
+			log.Info("Dashboard skipped as labels do not match:", request.Namespace, request.Name)
+			return reconcile.Result{Requeue: false}, nil
+		}
 
+	}
+	
 	client, err := r.getClient()
 	if err != nil {
 		return reconcile.Result{RequeueAfter: config.RequeueDelay}, nil

--- a/pkg/controller/grafanadashboard/dashboard_controller.go
+++ b/pkg/controller/grafanadashboard/dashboard_controller.go
@@ -116,8 +116,6 @@ func (r *ReconcileGrafanaDashboard) Reconcile(request reconcile.Request) (reconc
 		return reconcile.Result{Requeue: false}, nil
 	}
 
-	//return reconcile.Result{Requeue: false},nil
-
 	client, err := r.getClient()
 	if err != nil {
 		return reconcile.Result{RequeueAfter: config.RequeueDelay}, nil
@@ -242,7 +240,7 @@ func (r *ReconcileGrafanaDashboard) reconcileDashboards(request reconcile.Reques
 			r.config.SetPluginsFor(&dashboard)
 			continue
 		}
-
+		// Check labels only when DashboardNamespaceSelector isnt empty
 		if r.state.DashboardNamespaceSelector != nil {
 			matchesNamespaceLabels, err := r.checkNamespaceLabels(&dashboard)
 			if err != nil {


### PR DESCRIPTION
[Jira](https://issues.redhat.com/browse/INTLY-7239)

## Verification
1. Bring up the grafana operator using this branch
2. Modify the grafan cr to include the following 
``` 
dashboardNamespaceSelector:
    matchLabels:
      monitoring-key: middleware
```
2. Create 2 namespaces one without the namespace label "monitoring-key: middleware" the other with.
3. Inside each Namespace create a dashboard with the same label as above.
4. Check grafana you should see only the dashboard from the namespace with labels 