### PR TITLE
Fix for deadlock during rolling-upgrade

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -4,6 +4,10 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"os"
+	"runtime"
+	"strings"
+
 	"github.com/integr8ly/grafana-operator/v3/pkg/apis"
 	"github.com/integr8ly/grafana-operator/v3/pkg/controller"
 	"github.com/integr8ly/grafana-operator/v3/pkg/controller/common"
@@ -14,20 +18,16 @@ import (
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	"github.com/operator-framework/operator-sdk/pkg/leader"
 	"github.com/operator-framework/operator-sdk/pkg/metrics"
-	"github.com/operator-framework/operator-sdk/pkg/ready"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"k8s.io/client-go/rest"
-	"os"
-	"runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
-	"strings"
 )
 
 var log = logf.Log.WithName("cmd")
@@ -162,14 +162,6 @@ func main() {
 
 	// Become the leader before proceeding
 	leader.Become(context.TODO(), "grafana-operator-lock")
-
-	r := ready.NewFileReady()
-	err = r.Set()
-	if err != nil {
-		log.Error(err, "")
-		os.Exit(1)
-	}
-	defer r.Unset()
 
 	// Create a new Cmd to provide shared dependencies and start components
 	mgr, err := manager.New(cfg, manager.Options{

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -24,14 +24,6 @@ spec:
           command:
           - grafana-operator
           imagePullPolicy: Always
-          readinessProbe:
-            exec:
-              command:
-                - stat
-                - /tmp/operator-sdk-ready
-            initialDelaySeconds: 4
-            periodSeconds: 10
-            failureThreshold: 1
           env:
             - name: TEMPLATE_PATH
               value: /usr/local/bin/templates


### PR DESCRIPTION
JIRA Link: https://issues.redhat.com/browse/INTLY-8046

There is a dead lock, due to the code ordering. Suggestion was to remove
the readiness probe from the code. This occurs during a rolling update and not in
recreate strategy.

Verfied that the upgrade works for rolling upgrade and recreate.

Verified that there was no deadlock happening during the upgrade.