### PR TITLE
INTLY-8636 - Lower periodical reconcile loop to 1 hour

### DIFF
--- a/pkg/controller/config/controller_config.go
+++ b/pkg/controller/config/controller_config.go
@@ -24,7 +24,8 @@ const (
 	PluginsInitContainerImage       = "quay.io/integreatly/grafana_plugins_init"
 	PluginsInitContainerTag         = "0.0.2"
 	PluginsUrl                      = "https://grafana.com/api/plugins/%s/versions/%s"
-	RequeueDelay                    = time.Second * 10
+	RequeueDelay                    = time.Second * 10 // Used for timing the delay before invoking specific state managers, eg.ManageSuccess etc.
+	ReconcileLoopDelay              = time.Minute * 60 // Used for timing the periodical reconcile, currently set for 1 hour, separate to requeueDelay as setting that value to 1 hour would lead to massive delays in dashboard reconciles etc.
 	SecretsMountDir                 = "/etc/grafana-secrets/"
 	ConfigMapsMountDir              = "/etc/grafana-configmaps/"
 	ConfigRouteWatch                = "watch.routes"

--- a/pkg/controller/grafanadashboard/dashboard_controller.go
+++ b/pkg/controller/grafanadashboard/dashboard_controller.go
@@ -65,7 +65,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler, namespace string) error {
 	}
 
 	ref := r.(*ReconcileGrafanaDashboard)
-	ticker := time.NewTicker(config.RequeueDelay)
+	ticker := time.NewTicker(config.ReconcileLoopDelay)
 	sendEmptyRequest := func() {
 		request := reconcile.Request{
 			NamespacedName: types.NamespacedName{

--- a/pkg/controller/grafanadashboard/dashboard_controller.go
+++ b/pkg/controller/grafanadashboard/dashboard_controller.go
@@ -67,6 +67,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler, namespace string) error {
 	ref := r.(*ReconcileGrafanaDashboard)
 	ticker := time.NewTicker(config.ReconcileLoopDelay)
 	sendEmptyRequest := func() {
+		time.Sleep(time.Second * 10) //Needed for the initial immediate dashboard resync, if the function doesn't sleep then it will be called too fast and won't be able to find the grafana instance(which won't be available right away) and dashboards won't be reconciled until the next reconcileLoopDelay has elapsed
 		request := reconcile.Request{
 			NamespacedName: types.NamespacedName{
 				Namespace: namespace,
@@ -77,7 +78,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler, namespace string) error {
 	}
 
 	go func() {
-		for range ticker.C {
+		for ; true; <-ticker.C {
 			log.Info("running periodic dashboard resync")
 			sendEmptyRequest()
 		}

--- a/pkg/controller/grafanadatasource/datasource_controller.go
+++ b/pkg/controller/grafanadatasource/datasource_controller.go
@@ -70,9 +70,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler, namespace string) error {
 
 	ref := r.(*ReconcileGrafanaDataSource)
 
-	// The datasources should not change very often, only revisit them
-	// half as often as the dashboards
-	ticker := time.NewTicker(config.RequeueDelay * 2)
+	ticker := time.NewTicker(config.ReconcileLoopDelay)
 	sendEmptyRequest := func() {
 		request := reconcile.Request{
 			NamespacedName: types.NamespacedName{

--- a/pkg/controller/grafanadatasource/datasource_controller.go
+++ b/pkg/controller/grafanadatasource/datasource_controller.go
@@ -72,6 +72,8 @@ func add(mgr manager.Manager, r reconcile.Reconciler, namespace string) error {
 
 	ticker := time.NewTicker(config.ReconcileLoopDelay)
 	sendEmptyRequest := func() {
+		time.Sleep(time.Second * 10) //Needed for the initial immediate datasource resync, if the function doesn't sleep then it will be called too fast and won't be able to find the grafana instance(which won't be available right away) and datasources won't be reconciled until the next reconcileLoopDelay has elapsed
+
 		request := reconcile.Request{
 			NamespacedName: types.NamespacedName{
 				Namespace: namespace,
@@ -82,7 +84,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler, namespace string) error {
 	}
 
 	go func() {
-		for range ticker.C {
+		for ; true; <-ticker.C {
 			log.Info("running periodic datasource resync")
 			sendEmptyRequest()
 		}


### PR DESCRIPTION
# Description
Lower periodical reconcile loop to 1 hour, as opposed to every minute or so, all changes to dashboards/datasources should be reconciled upon crud operations and the operator should pick up on those when they happen.

## JIRA
https://issues.redhat.com/browse/INTLY-8636

## Verification
- Checkout the master branch.
- Follow the [manual procedure to install grafana](https://github.com/integr8ly/grafana-operator/blob/master/documentation/deploy_grafana.md#manual-procedure). (*Skip the step for deploying the operator.yaml*).
- [Deploy the Grafana CR](https://github.com/integr8ly/grafana-operator/blob/master/documentation/deploy_grafana.md#deploying-grafana).
- run `make code/run`.
- check the operator logs in your CLI to verify that periodical reconciles for datasources and dashboards occur often (roughly every 10 seconds or so).
- Create a dashboard in the `grafana` namespace using `oc create -f deploy/examples/dashboards/SimpleDashboard.json -n grafana`, and ensure that it gets reconciled in the Grafana CR dashboard list.
- Stop the operator from running locally.
- Checkout this Branch, and `make code/run`.
- Verify that the periodical reconcile for datasources and dashboards isn't being called when running as often as previously(It should take an hour before the first periodical reconcile is called for those).
- Delete the dashboard using `oc delete grafanadashboard simple-dashboard -n grafana` and ensure that it gets removed in the Grafana CR dashboard list.
- Optionally wait until the first periodical reconcile is called after an hour. (Might be a good idea to leave it running in the background and write the logs to a file, then grep the file for any instance of `periodical`)