### PR TITLE
Need deployment finalizer for metrics service

### DIFF
--- a/deploy/roles/role.yaml
+++ b/deploy/roles/role.yaml
@@ -39,6 +39,7 @@ rules:
       - apps
     resources:
       - deployments
+      - deployments/finalizers
       - daemonsets
       - replicasets
       - statefulsets


### PR DESCRIPTION
deploy/roles/role.yaml is missing a "deployments/finalizers" resource in the "app" group. Without it, a service for "grafana-operator-metrics" is not created and an error is written to the logs. This maybe due to an upstream issue in the operator-sdk.

Before:
``` json
{
   "level":"error",
   "ts":1593431909.364457,
   "logger":"cmd",
   "msg":"error starting metrics service",
   "error":"failed to create or get service for metrics: services \"grafana-operator-metrics\" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>",
   "stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\tgrafana-operator/vendor/github.com/go-logr/zapr/zapr.go:128\nmain.main\n\tgrafana-operator/cmd/manager/main.go:215\nruntime.main\n\t/home/travis/.gimme/versions/go1.13.12.linux.amd64/src/runtime/proc.go:203"
}
```

After:
``` json
{
   "level":"info",
   "ts":1593431974.4090142,
   "logger":"metrics",
   "msg":"Metrics Service object updated",
   "Service.Name":"grafana-operator-metrics",
   "Service.Namespace":"grafana"
}
```