### PR TITLE
Add documentation for running the operator on minikube

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,8 +74,3 @@ operator/deploy: cluster/prepare/local
 .PHONY: operator/stop
 operator/stop:
 	-kubectl delete deployment grafana-operator -n ${NAMESPACE}
-
-.PHONY: minikube/cleanup
-minikube/cleanup:
-	minikube stop
-	minikube delete

--- a/Makefile
+++ b/Makefile
@@ -54,21 +54,25 @@ test/unit:
 	@echo Running tests:
 	go test -v -race -cover ./pkg/...
 
-.PHONY: minikube/prepare/local
-minikube/prepare/local:
+.PHONY: cluster/prepare/local
+cluster/prepare/local:
 	-kubectl create namespace ${NAMESPACE}
 	kubectl apply -f deploy/crds
 	kubectl apply -f deploy/roles -n ${NAMESPACE}
 	kubectl apply -f deploy/cluster_roles
 	kubectl apply -f deploy/examples/Grafana.yaml -n ${NAMESPACE}
 
+.PHONY: cluster/cleanup	
+cluster/cleanup: operator/stop
+	-kubectl delete deployment grafana-deployment -n ${NAMESPACE}
+	-kubectl delete namespace ${NAMESPACE}
 
-.PHONY: minikube/deploy
-minikube/deploy: minikube/prepare/local
+.PHONY: operator/deploy
+operator/deploy: cluster/prepare/local
 	kubectl apply -f deploy/operator.yaml -n ${NAMESPACE}
 
-.PHONY: minikube/operator/stop
-minikube/stop:
+.PHONY: operator/stop
+operator/stop:
 	-kubectl delete deployment grafana-operator -n ${NAMESPACE}
 
 .PHONY: minikube/cleanup

--- a/Makefile
+++ b/Makefile
@@ -67,11 +67,11 @@ minikube/prepare/local:
 minikube/deploy: minikube/prepare/local
 	kubectl apply -f deploy/operator.yaml -n ${NAMESPACE}
 
-.PHONY: minikube/stop
+.PHONY: minikube/operator/stop
 minikube/stop:
 	-kubectl delete deployment grafana-operator -n ${NAMESPACE}
 
 .PHONY: minikube/cleanup
-minikube/cleanup: minikube/stop
+minikube/cleanup:
 	minikube stop
 	minikube delete

--- a/Makefile
+++ b/Makefile
@@ -53,3 +53,25 @@ image/build/push: image/build image/push
 test/unit:
 	@echo Running tests:
 	go test -v -race -cover ./pkg/...
+
+.PHONY: minikube/prepare/local
+minikube/prepare/local:
+	-kubectl create namespace ${NAMESPACE}
+	kubectl apply -f deploy/crds
+	kubectl apply -f deploy/roles -n ${NAMESPACE}
+	kubectl apply -f deploy/cluster_roles
+	kubectl apply -f deploy/examples/Grafana.yaml -n ${NAMESPACE}
+
+
+.PHONY: minikube/deploy
+minikube/deploy: minikube/prepare/local
+	kubectl apply -f deploy/operator.yaml -n ${NAMESPACE}
+
+.PHONY: minikube/stop
+minikube/stop:
+	-kubectl delete deployment grafana-operator -n ${NAMESPACE}
+
+.PHONY: minikube/cleanup
+minikube/cleanup: minikube/stop
+	minikube stop
+	minikube delete

--- a/documentation/deploy_grafana.md
+++ b/documentation/deploy_grafana.md
@@ -40,6 +40,9 @@ ansible-playbook deploy/ansible/grafana-operator-namespace-resources.yaml \
   -e grafana_operator_namespace=grafana
 ```
 
+### Minikube deployment
+Follow this documentation [Deploying the Grafana operator in minikube](./minikube.md)
+
 ### Manual Procedure
 
 To create a namespace named `grafana` run:

--- a/documentation/deploy_grafana.md
+++ b/documentation/deploy_grafana.md
@@ -8,6 +8,9 @@ The first step is to install the Grafana operator to a namespace in your cluster
 
 There are two options for this procedure, automated via Ansible, or manually running kubectl/oc commands.
 
+### Deploy an example grafana instance and operator
+Run `make operator/deploy` This uses the default operator.yaml and Grafana.yaml resources found in the `deploy` directories and subdirectories.
+
 ### Automated Procedure
 
 Cluster admin install cluster resources.

--- a/documentation/minikube.md
+++ b/documentation/minikube.md
@@ -10,7 +10,7 @@ Grafana operator is a relatively small and non-resource intensive operator, it c
 "Locally" in this case refers to running the operator in the CLI i.e. not as a deployment on the minikube cluster. for that see the next section.
 
 1. Start the minikube cluster using `minikube start (--vm-driver=<driver>)` the part in the parentheses is optional. for more info read back through the minikube product documentation.
-2. To prepare the local instance of grafana run `make minikube/prepare/local`, this will create a new instance of grafana in the grafana namespace (to edit this edit the NAMESPACE field in the makefile).
+2. To prepare the local instance of grafana run `make cluster/prepare/local`, this will create a new instance of grafana in the grafana namespace (to edit this edit the NAMESPACE field in the makefile).
 3. Run the operator with `make code/run` or `operator-sdk up local --namespace=grafana"
 4. The ingress readiness probe will most likely fail, after a few seconds, from a new terminal window run `minikube addonsenable ingress`
 5. The operator should now see the ingress and proceed with deployment. Optionally to confirm that the ingress is reachable `kubectl get ingress -n grafana` and ensure that the address is not empty.
@@ -18,13 +18,17 @@ Grafana operator is a relatively small and non-resource intensive operator, it c
 To stop the operator `ctrl + c` in the terminal with the operator running.
 ## Running the operator on the minikube cluster
 1. Start the minikube cluster using `minikube start (--vm-driver=<driver>)` the part in the parentheses is optional. for more info read back through the minikube product documentation.
-2. Run the deployment with `make minikube/deploy`, this will deploy the operator on the cluster and will be ready in a few seconds.
+2. Run the deployment with `make operator/deploy`, this will deploy the operator on the cluster and will be ready in a few seconds.
 
-to stop the operator run `make minikube/operator/stop`, this will delete the operator deployment from the cluster.
+to stop the operator run `make operator/stop`, this will delete the operator deployment from the cluster.
 
-to re-deploy the operator run `make minikube/deploy`
+to re-deploy the operator run `make operator/deploy`
 ## Cleanup
+To cleanup the cluster from Grafana resources (only in the grafana namespace):
+Run `make cluster/cleanup`
+
 To completely remove the minikube cluster and all associated resources:
 Run `make minikube/cleanup`
+
 
 

--- a/documentation/minikube.md
+++ b/documentation/minikube.md
@@ -9,9 +9,21 @@ Grafana operator is a relatively small and non-resource intensive operator, it c
 ## Running the operator "Locally"
 "Locally" in this case refers to running the operator in the CLI i.e. not as a deployment on the minikube cluster. for that see the next section.
 
-1. start the minikube cluster using `minikube start (--vm-driver=<driver>)` the part in the parentheses is optional. for more info read back through the minikube product documentation
+1. Start the minikube cluster using `minikube start (--vm-driver=<driver>)` the part in the parentheses is optional. for more info read back through the minikube product documentation.
+2. To prepare the local instance of grafana run `make minikube/prepare/local`, this will create a new instance of grafana in the grafana namespace (to edit this edit the NAMESPACE field in the makefile).
+3. Run the operator with `make code/run` or `operator-sdk up local --namespace=grafana"
+4. The ingress readiness probe will most likely fail, after a few seconds, from a new terminal window run `minikube addonsenable ingress`
+5. The operator should now see the ingress and proceed with deployment. Optionally to confirm that the ingress is reachable `kubectl get ingress -n grafana` and ensure that the address is not empty.
 
+To stop the operator `ctrl + c` in the terminal with the operator running.
+## Running the operator on the minikube cluster
+1. Start the minikube cluster using `minikube start (--vm-driver=<driver>)` the part in the parentheses is optional. for more info read back through the minikube product documentation.
+2. Run the deployment with `make minikube/deploy`, this will deploy the operator on the cluster and will be ready in a few seconds.
 
-## Running the operator on minikube cluster
+to stop the operator run `make minikube/stop`, this will delete the operator deployment from the cluster.
+
+## Cleanup
+To completely remove the minikube cluster and all associated resources:
+Run `make minikube/cleanup`
 
 

--- a/documentation/minikube.md
+++ b/documentation/minikube.md
@@ -28,7 +28,7 @@ To cleanup the cluster from Grafana resources (only in the grafana namespace):
 Run `make cluster/cleanup`
 
 To completely remove the minikube cluster and all associated resources:
-Run `make minikube/cleanup`
+Run `minikube stop` and `minikube delete` after the minikube cluster has stopped.
 
 
 

--- a/documentation/minikube.md
+++ b/documentation/minikube.md
@@ -20,8 +20,9 @@ To stop the operator `ctrl + c` in the terminal with the operator running.
 1. Start the minikube cluster using `minikube start (--vm-driver=<driver>)` the part in the parentheses is optional. for more info read back through the minikube product documentation.
 2. Run the deployment with `make minikube/deploy`, this will deploy the operator on the cluster and will be ready in a few seconds.
 
-to stop the operator run `make minikube/stop`, this will delete the operator deployment from the cluster.
+to stop the operator run `make minikube/operator/stop`, this will delete the operator deployment from the cluster.
 
+to re-deploy the operator run `make minikube/deploy`
 ## Cleanup
 To completely remove the minikube cluster and all associated resources:
 Run `make minikube/cleanup`

--- a/documentation/minikube.md
+++ b/documentation/minikube.md
@@ -1,0 +1,17 @@
+# Deploying the Grafana operator in minikube
+Grafana operator is a relatively small and non-resource intensive operator, it can be deployed independently on minikube, which makes it very convenient for testing and development purposes, Minikubes can be quickly disposed of and restarted without much downtime. it runs locally and provides almost all the functionality required to run this operator "out of the box"
+
+## Prerequisites
+- [Minikube installed](https://kubernetes.io/docs/tasks/tools/install-minikube/)
+- Kubectl / OC - For managing the minikube cluster
+- Local clone of this repository
+
+## Running the operator "Locally"
+"Locally" in this case refers to running the operator in the CLI i.e. not as a deployment on the minikube cluster. for that see the next section.
+
+1. start the minikube cluster using `minikube start (--vm-driver=<driver>)` the part in the parentheses is optional. for more info read back through the minikube product documentation
+
+
+## Running the operator on minikube cluster
+
+


### PR DESCRIPTION
## Description
Adding some documentation around running and setting up the operator in minikube, easy option for developing the operator without an actual cluster.
This is intended to be a living document, with additions as needed.