### PR TITLE
Add configmap for OCP oath example

### DIFF
--- a/deploy/examples/oauth/Grafana.yaml
+++ b/deploy/examples/oauth/Grafana.yaml
@@ -31,6 +31,7 @@ spec:
         - '-openshift-service-account=grafana-serviceaccount'
         - '-openshift-ca=/etc/pki/tls/cert.pem'
         - '-openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt'
+        - '-openshift-ca=/etc/grafana-configmaps/ocp-injected-certs/ca-bundle.crt'
         - '-skip-auth-regex=^/metrics'
       image: 'quay.io/openshift/origin-oauth-proxy:4.2'
       name: grafana-proxy
@@ -48,6 +49,8 @@ spec:
   secrets:
     - grafana-k8s-tls
     - grafana-k8s-proxy
+  configMaps:
+    - ocp-injected-certs
   service:
     ports:
       - name: grafana-proxy

--- a/deploy/examples/oauth/README.md
+++ b/deploy/examples/oauth/README.md
@@ -6,4 +6,5 @@ This example shows how to combine Grafana with the [OpenShift OAuthProxy](https:
 
 1. Create the [session secret](./session-secret.yaml) in the same namespace as Grafana.
 2. Create the additional [cluster role](./cluster_role.yaml) and [binding](./cluster_role_binding.yaml).
-3. Create Grafana from the [CR](./Grafana.yaml) in this example.
+3. Create the [config map](./ocp-injected-certs.yaml) in the same namespace as Grafana.
+4. Create Grafana from the [CR](./Grafana.yaml) in this example.

--- a/deploy/examples/oauth/ocp-injected-certs.yml
+++ b/deploy/examples/oauth/ocp-injected-certs.yml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    config.openshift.io/inject-trusted-cabundle: "true"
+  name: ocp-injected-certs


### PR DESCRIPTION
Due to what happens when you add a custom certificate to OCP you need to add the root ca to the operator.
Explained here: https://docs.openshift.com/container-platform/4.4/networking/configuring-a-custom-pki.html#certificate-injection-using-operators_configuring-a-custom-pki

It also works when you haven't added a custom ca :)
