### PR TITLE
Make grafna-operator upgrade dashboards/status

### DIFF
--- a/deploy/cluster_roles/cluster_role_grafana_operator.yaml
+++ b/deploy/cluster_roles/cluster_role_grafana_operator.yaml
@@ -7,6 +7,7 @@ rules:
       - integreatly.org
     resources:
       - grafanadashboards
+      - grafanadashboards/status
     verbs: ['get', 'list', 'update', 'watch']
   - apiGroups:
       - ""


### PR DESCRIPTION
Without this access the grafna-operator gets the following error:
{"level":"error","ts":1594468103.7226772,"logger":"controller_grafanadashboard","msg":"error updating dashboard status","error":"grafanadashboards.integreatly.org \"keycloak-dashboard\" is forbidden: User \"system:serviceaccount:grafana:grafana-operator\" cannot update resource \"grafanadashboards/status\" in API group \"integreatly.org\" in the namespace \"grafana\"","stacktrace":"github.com/go-logr/zapr.(*zapLogger).
