### PR TITLE
support stackdriver datasource options

### DIFF
--- a/deploy/examples/datasources/Stackdriver.yaml
+++ b/deploy/examples/datasources/Stackdriver.yaml
@@ -1,0 +1,23 @@
+apiVersion: integreatly.org/v1alpha1
+kind: GrafanaDataSource
+metadata:
+  name: stackdriver-data-source
+spec:
+  datasources:
+    - name: Stackdriver
+      type: stackdriver
+      access: proxy
+      editable: false
+      isDefault: false
+      jsonData:
+        tokenUri: https://oauth2.googleapis.com/token
+        clientEmail: grafana@my-project.iam.gserviceaccount.com
+        authenticationType: jwt
+        defaultProject: my-project
+      secureJsonData:
+        privateKey: |
+          -----BEGIN PRIVATE KEY-----
+          .....
+          -----END PRIVATE KEY-----
+      version: 1
+  name: stackdriver-data-source.yaml

--- a/pkg/apis/integreatly/v1alpha1/grafanadatasource_types.go
+++ b/pkg/apis/integreatly/v1alpha1/grafanadatasource_types.go
@@ -115,6 +115,11 @@ type GrafanaDataSourceJsonData struct {
 	HTTPHeaderName7 string `json:"httpHeaderName7,omitempty"`
 	HTTPHeaderName8 string `json:"httpHeaderName8,omitempty"`
 	HTTPHeaderName9 string `json:"httpHeaderName9,omitempty"`
+	// Fields for Stackdriver data sources
+	TokenUri           string `json:"tokenUri,omitempty"`
+	ClientEmail        string `json:"clientEmail,omitempty"`
+	AuthenticationType string `json:"authenticationType,omitempty"`
+	DefaultProject     string `json:"defaultProject,omitempty"`
 }
 
 // The most common secure json options
@@ -138,6 +143,8 @@ type GrafanaDataSourceSecureJsonData struct {
 	HTTPHeaderValue7 string `json:"httpHeaderValue7,omitempty"`
 	HTTPHeaderValue8 string `json:"httpHeaderValue8,omitempty"`
 	HTTPHeaderValue9 string `json:"httpHeaderValue9,omitempty"`
+	// Fields for Stackdriver data sources
+	PrivateKey string `json:"privateKey,omitempty"`
 }
 
 func init() {


### PR DESCRIPTION
fixes #220 

Adds datasource `jsonData` and `secureJsonData` options to support stackdriver. Also adds an example DS.