### PR TITLE
Use hyphen branch separator

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,6 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
+    pull-request-branch-name:
+      # Use hyphen to ensure valid tag for container image
+      separator: "-"


### PR DESCRIPTION
Fix for
```
Error parsing reference: "quay.io/integreatly/grafana-operator:dependabot/go_modules/github.com/pkg/errors-0.9.1" is not a valid repository/tag: invalid reference format
```