### PR TITLE
fix: jsonnet changes in dashboards went undetected

### DIFF
--- a/pkg/controller/grafanadashboard/dashboard_pipeline.go
+++ b/pkg/controller/grafanadashboard/dashboard_pipeline.go
@@ -180,8 +180,8 @@ func (r *DashboardPipelineImpl) generateHash() string {
 		datasources.WriteString(input.InputName)
 	}
 
-	return fmt.Sprintf("%x", md5.Sum([]byte(
-		r.Dashboard.Spec.Json+r.Dashboard.Spec.Url+datasources.String())))
+	return fmt.Sprintf("%x", md5.Sum([]byte(r.Dashboard.Spec.Json+
+		r.Dashboard.Spec.Url+r.Dashboard.Spec.Jsonnet+datasources.String())))
 }
 
 // Try to obtain the dashboard json from a provided url


### PR DESCRIPTION
Fixes the issue where a change in a jsonnet dashbaord was not reconciled. The hash did not include the jsonnet source code.