### PR TITLE
support grafana headless service and no overwrite nodeport

### DIFF
--- a/pkg/apis/integreatly/v1alpha1/grafana_types.go
+++ b/pkg/apis/integreatly/v1alpha1/grafana_types.go
@@ -51,6 +51,7 @@ type GrafanaService struct {
 	Labels      map[string]string `json:"labels,omitempty"`
 	Type        v1.ServiceType    `json:"type,omitempty"`
 	Ports       []v1.ServicePort  `json:"ports,omitempty"`
+	ClusterIP   string            `json:"clusterIP,omitempty"`
 }
 
 // GrafanaDataStorage provides a means to configure the grafana data storage

--- a/pkg/controller/grafana/grafana_controller.go
+++ b/pkg/controller/grafana/grafana_controller.go
@@ -240,7 +240,7 @@ func (r *ReconcileGrafana) getGrafanaAdminUrl(cr *grafanav1alpha1.Grafana, state
 	var servicePort = int32(model.GetGrafanaPort(cr))
 
 	// Otherwise rely on the service
-	if state.GrafanaService != nil && state.GrafanaService.Spec.ClusterIP != "" {
+	if state.GrafanaService != nil && state.GrafanaService.Spec.ClusterIP != "" && state.GrafanaService.Spec.ClusterIP != "None" {
 		return fmt.Sprintf("http://%v:%d", state.GrafanaService.Spec.ClusterIP,
 			servicePort), nil
 	} else if state.GrafanaService != nil {

--- a/pkg/controller/model/grafanaService.go
+++ b/pkg/controller/model/grafanaService.go
@@ -70,8 +70,7 @@ func getServicePorts(cr *v1alpha1.Grafana, currentState *v1.Service) []v1.Servic
 
 	// Re-assign existing node port
 	if cr.Spec.Service != nil &&
-		currentState != nil &&
-		cr.Spec.Service.Type == v1.ServiceTypeNodePort {
+		currentState != nil {
 		for _, port := range currentState.Spec.Ports {
 			if port.Name == GrafanaHttpPortName {
 				defaultPorts[0].NodePort = port.NodePort

--- a/pkg/controller/model/grafanaService.go
+++ b/pkg/controller/model/grafanaService.go
@@ -35,6 +35,13 @@ func getServiceType(cr *v1alpha1.Grafana) v1.ServiceType {
 	return cr.Spec.Service.Type
 }
 
+func getClusterIP(cr *v1alpha1.Grafana) string {
+	if cr.Spec.Service == nil {
+		return ""
+	}
+	return cr.Spec.Service.ClusterIP
+}
+
 func GetGrafanaPort(cr *v1alpha1.Grafana) int {
 	if cr.Spec.Config.Server == nil {
 		return GrafanaHttpPort
@@ -107,7 +114,7 @@ func GrafanaService(cr *v1alpha1.Grafana) *v1.Service {
 			Selector: map[string]string{
 				"app": GrafanaPodLabel,
 			},
-			ClusterIP: cr.Spec.Service.ClusterIP,
+			ClusterIP: getClusterIP(cr),
 			Type:      getServiceType(cr),
 		},
 	}

--- a/pkg/controller/model/grafanaService.go
+++ b/pkg/controller/model/grafanaService.go
@@ -1,12 +1,13 @@
 package model
 
 import (
+	"strconv"
+
 	"github.com/integr8ly/grafana-operator/v3/pkg/apis/integreatly/v1alpha1"
 	v1 "k8s.io/api/core/v1"
 	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"strconv"
 )
 
 func getServiceLabels(cr *v1alpha1.Grafana) map[string]string {
@@ -107,7 +108,7 @@ func GrafanaService(cr *v1alpha1.Grafana) *v1.Service {
 			Selector: map[string]string{
 				"app": GrafanaPodLabel,
 			},
-			ClusterIP: "",
+			ClusterIP: cr.Spec.Service.ClusterIP,
 			Type:      getServiceType(cr),
 		},
 	}


### PR DESCRIPTION
1. in some cases, we need to deploy headless service, this PR aims to support it.
2. For loadbalancer type service, nodeport is continually overwrote by operator that cause lb service created failed. So do not overwrite nodeport.