### PR TITLE
Update Readme and Dashboards.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,24 @@
 
 A Kubernetes Operator based on the Operator SDK for creating and managing Grafana instances.
 
+## Grafana Operator on the Kubernetes community Slack
+We have set up a channel dedicated to this operator on the Kubernetes community Slack, this is an easier way to address 
+more immediate issues and facilitate discussion around development/bugs etc. as well as providing support for questions
+about the operator.
+    
+1: Join the Kubernetes Slack (if you have not done so already) [Kubernetes Slack](https://slack.k8s.io/).
+    
+2: You will receive an email with an invitation link, follow that link and enter your desired username and password for the workspace(it might be easier if you use your Github username for our channel).
+    
+3: Once registered and able to see the Kubernetes community Slack workspace and channels follow this link to the [grafana-operator channel](https://kubernetes.slack.com/messages/grafana-operator/ ).
+    
+Alternatively:
+If you're already a member of that workspace then just follow this link to the [grafana-operator channel](https://kubernetes.slack.com/messages/grafana-operator/ ) or search for "grafana-operator" in the browse channels option .
+
+![image](https://user-images.githubusercontent.com/35736504/90978105-0b195300-e543-11ea-86ee-1825da0e3b75.png)
+    
+
+
 # Current status
 
 The Operator is available on [Operator Hub](https://operatorhub.io/operator/grafana-operator).

--- a/documentation/dashboards.md
+++ b/documentation/dashboards.md
@@ -36,7 +36,7 @@ If the dashboard contains invalid JSON a message with the parser error will be a
 
 ## Plugins
 
-Dashboards can specify plugins (panels) they depend on. The operator will automatically install them.
+Dashboards can specify plugins they depend on. The operator will automatically install them.
 
 You need to provide a name and a version for every plugin, e.g.:
 


### PR DESCRIPTION
- Added information about the grafana-operator slack channel
- Removed "panels" from the plugin section of dashboards.md, this caused some confusion previously. 