### PR TITLE
change service targerport to number

### DIFF
--- a/pkg/controller/model/grafanaService.go
+++ b/pkg/controller/model/grafanaService.go
@@ -67,7 +67,7 @@ func getServicePorts(cr *v1alpha1.Grafana, currentState *v1.Service) []v1.Servic
 			Name:       GrafanaHttpPortName,
 			Protocol:   "TCP",
 			Port:       intPort,
-			TargetPort: intstr.FromString("grafana-http"),
+			TargetPort: intstr.FromInt(GetGrafanaPort(cr)),
 		},
 	}
 


### PR DESCRIPTION
In some environment, service controller cannot respect the targetport as a string.
I wonder whether there is a case that need a string rather than a port number.