### PR TITLE
pkg/controller/grafanadashboard: avoid refetching URL

### DIFF
--- a/pkg/controller/grafanadashboard/dashboard_controller.go
+++ b/pkg/controller/grafanadashboard/dashboard_controller.go
@@ -256,7 +256,7 @@ func (r *ReconcileGrafanaDashboard) reconcileDashboards(request reconcile.Reques
 		// to determine if an update is required
 		knownHash := findHash(&dashboard)
 
-		pipeline := NewDashboardPipeline(r.client, &dashboard)
+		pipeline := NewDashboardPipeline(r.client, &dashboard, r.context)
 		processed, err := pipeline.ProcessDashboard(knownHash, &folderId, folderName)
 
 		if err != nil {


### PR DESCRIPTION
If dashboard has only URL set in `GrafanaDashboard` spec, the operator should fetch it once and avoid refetching it on every reconciliation. Fetched contents would be written in `.spec.json`.

Dashboard provider may start throwing "429 Too Many Requests" after some time (i.e. grafana.com),
so dashboard can no longer be fetched.
URL may change contents, so users should remove `.spec.json` in order to refetch dashboard contents.

Related to #45 (not entirely sure if it fixes it)