### PR TITLE
Set grafonnet release hash to v0.1.0 and add `ignore=dirty` to submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "grafonnet-lib"]
 	path = grafonnet-lib
 	url = https://github.com/grafana/grafonnet-lib
+	ignore = dirty


### PR DESCRIPTION
- setting the release hash to v0.1.0 for the grafonnet-lib submodule
- adding ignore field for dirty repo states : `Dirty status = the repo in question has tracked files (files that have previously been committed) that have modifications that have not been committed, and/or there are new untracked files. ` 