### PR TITLE
add pull request template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+
+## Description
+<!-- Please include a summary of the changes, Please add any additional motivation and context as needed -->
+
+## Relevant issues/tickets
+<!-- Please include a link to the issue or ticket that applies to this pull request, delete this heading if not relevant -->
+
+## Type of change
+
+<!-- Please delete options that are not relevant. -->
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+
+## Checklist
+- [ ] This change requires a documentation update 
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] I have added a test case that will be used to verify my changes 
+- [ ] Verified independently on a cluster by reviewer
+
+## Verification steps
+<!-- Please include a series of steps to verify that the functionality/bug fix works, ideally the steps you used to test these changes(if applicable, if not, delete this section)-->

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -14,6 +14,7 @@
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 
 ## Checklist
+<!-- Tick options that apply, in-code tests are not required but please provide test cases and list steps in "verification steps" with the steps you used to verify this -->
 - [ ] This change requires a documentation update 
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] I have added a test case that will be used to verify my changes 


### PR DESCRIPTION
Adding a pull request template, to streamline the process and allow reviewers to get the relevant and required information.
Based mostly on the integreatly-operator pull request template, since that seemed to have worked well for that repo I don't see a reason why it wouldn't for this one.