### PR TITLE
Admin creds from env

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -6,6 +6,7 @@
 * [Multi namespace support](./multi_namespace_support.md)
 * [Mounting extra config files](./extra_files.md)
 * [Jsonnet support](./jsonnet.md)
+* [Env vars](./env_vars.md)
 
 ## Examples
 

--- a/documentation/env_vars.md
+++ b/documentation/env_vars.md
@@ -1,0 +1,25 @@
+# Exposing environment variables to the Grafana container
+
+You can expose extra environment variables to the Grafana container from secrets or config maps in the same namespace as the Grafana CR:
+
+```yaml
+spec:
+  deployment:
+    skipCreateAdminAccount: true
+    envFrom:
+      - secretRef:
+          name: external-credentials
+      - configMapRef:
+          name: extra-vars
+```
+
+This adds all the key value pairs from the secret `external-credentials` and the config map `extra-vars` to the Grafana container.
+
+## Requirements when providing external admin credentials
+
+Typically, this feature is used to provide the credentials for the Grafana admin account. In that case, the following needs to be assured:
+
+1. Admin credentials must be provided via the `GF_SECURITY_ADMIN_USER` and `GF_SECURITY_ADMIN_PASSWORD` environment variables.
+2. Set `skipCreateAdminAccount` to `true` to prevent the operator from creating an admin secret.
+
+*NOTE*: The operator still requires an admin account to interact with Grafana. It will try to obtain the credentials from the provided secrets or config maps.

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v0.1.0
-	github.com/go-openapi/spec v0.19.4
 	github.com/google/go-jsonnet v0.16.0
 	github.com/openshift/api v3.9.0+incompatible
 	github.com/operator-framework/operator-sdk v0.18.2
@@ -14,7 +13,6 @@ require (
 	k8s.io/api v0.18.2
 	k8s.io/apimachinery v0.18.2
 	k8s.io/client-go v12.0.0+incompatible
-	k8s.io/kube-openapi v0.0.0-20200121204235-bf4fb3bd569c
 	sigs.k8s.io/controller-runtime v0.6.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -328,8 +328,6 @@ github.com/go-openapi/spec v0.18.0/go.mod h1:XkF/MOi14NmjsfZ8VtAKf8pIlbZzyoTvZsd
 github.com/go-openapi/spec v0.19.2/go.mod h1:sCxk3jxKgioEJikev4fgkNmwS+3kuYdJtcsZsD5zxMY=
 github.com/go-openapi/spec v0.19.3 h1:0XRyw8kguri6Yw4SxhsQA/atC88yqrk0+G4YhI2wabc=
 github.com/go-openapi/spec v0.19.3/go.mod h1:FpwSN1ksY1eteniUU7X0N/BgJ7a4WvBFVA8Lj9mJglo=
-github.com/go-openapi/spec v0.19.4 h1:ixzUSnHTd6hCemgtAJgluaTSGYpLNpJY4mA2DIkdOAo=
-github.com/go-openapi/spec v0.19.4/go.mod h1:FpwSN1ksY1eteniUU7X0N/BgJ7a4WvBFVA8Lj9mJglo=
 github.com/go-openapi/strfmt v0.17.0/go.mod h1:P82hnJI0CXkErkXi8IKjPbNBM6lV6+5pLP5l494TcyU=
 github.com/go-openapi/strfmt v0.17.2/go.mod h1:P82hnJI0CXkErkXi8IKjPbNBM6lV6+5pLP5l494TcyU=
 github.com/go-openapi/strfmt v0.18.0/go.mod h1:P82hnJI0CXkErkXi8IKjPbNBM6lV6+5pLP5l494TcyU=

--- a/pkg/controller/common/controllerState.go
+++ b/pkg/controller/common/controllerState.go
@@ -7,8 +7,6 @@ var ControllerEvents = make(chan ControllerState, 1)
 type ControllerState struct {
 	DashboardSelectors         []*v1.LabelSelector
 	DashboardNamespaceSelector *v1.LabelSelector
-	AdminUsername              string
-	AdminPassword              string
 	AdminUrl                   string
 	GrafanaReady               bool
 	ClientTimeout              int

--- a/pkg/controller/grafana/grafana_controller.go
+++ b/pkg/controller/grafana/grafana_controller.go
@@ -265,10 +265,6 @@ func (r *ReconcileGrafana) manageSuccess(cr *grafanav1alpha1.Grafana, state *com
 		}
 	}
 
-	if state.AdminSecret == nil || state.AdminSecret.Data == nil {
-		return r.manageError(cr, stdErr.New("admin secret not found or invalid"))
-	}
-
 	err := r.client.Status().Update(r.context, cr)
 	if err != nil {
 		return r.manageError(cr, err)

--- a/pkg/controller/grafana/grafana_controller.go
+++ b/pkg/controller/grafana/grafana_controller.go
@@ -284,8 +284,6 @@ func (r *ReconcileGrafana) manageSuccess(cr *grafanav1alpha1.Grafana, state *com
 	controllerState := common.ControllerState{
 		DashboardSelectors:         cr.Spec.DashboardLabelSelector,
 		DashboardNamespaceSelector: cr.Spec.DashboardNamespaceSelector,
-		AdminUsername:              string(state.AdminSecret.Data[model.GrafanaAdminUserEnvVar]),
-		AdminPassword:              string(state.AdminSecret.Data[model.GrafanaAdminPasswordEnvVar]),
 		AdminUrl:                   url,
 		GrafanaReady:               true,
 		ClientTimeout:              DefaultClientTimeoutSeconds,

--- a/pkg/controller/grafanadashboard/dashboard_controller.go
+++ b/pkg/controller/grafanadashboard/dashboard_controller.go
@@ -7,12 +7,14 @@ import (
 	grafanav1alpha1 "github.com/integr8ly/grafana-operator/v3/pkg/apis/integreatly/v1alpha1"
 	"github.com/integr8ly/grafana-operator/v3/pkg/controller/common"
 	"github.com/integr8ly/grafana-operator/v3/pkg/controller/config"
+	"github.com/integr8ly/grafana-operator/v3/pkg/controller/model"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
+	"os"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -363,12 +365,12 @@ func (r *ReconcileGrafanaDashboard) getClient() (GrafanaClient, error) {
 		return nil, defaultErrors.New("cannot get grafana admin url")
 	}
 
-	username := r.state.AdminUsername
+	username := os.Getenv(model.GrafanaAdminUserEnvVar)
 	if username == "" {
 		return nil, defaultErrors.New("invalid credentials (username)")
 	}
 
-	password := r.state.AdminPassword
+	password := os.Getenv(model.GrafanaAdminPasswordEnvVar)
 	if password == "" {
 		return nil, defaultErrors.New("invalid credentials (password)")
 	}

--- a/pkg/controller/model/adminUserSecret.go
+++ b/pkg/controller/model/adminUserSecret.go
@@ -4,6 +4,7 @@ import (
 	"github.com/integr8ly/grafana-operator/v3/pkg/apis/integreatly/v1alpha1"
 	v12 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"os"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -30,10 +31,17 @@ func getAdminPassword(cr *v1alpha1.Grafana, current *v12.Secret) []byte {
 }
 
 func getData(cr *v1alpha1.Grafana, current *v12.Secret) map[string][]byte {
-	return map[string][]byte{
+	credentials := map[string][]byte{
 		GrafanaAdminUserEnvVar:     getAdminUser(cr, current),
 		GrafanaAdminPasswordEnvVar: getAdminPassword(cr, current),
 	}
+
+	// Make the credentials available to the environment when running the operator
+	// outside of the cluster
+	os.Setenv(GrafanaAdminUserEnvVar, string(credentials[GrafanaAdminUserEnvVar]))
+	os.Setenv(GrafanaAdminPasswordEnvVar, string(credentials[GrafanaAdminPasswordEnvVar]))
+
+	return credentials
 }
 
 func AdminSecret(cr *v1alpha1.Grafana) *v12.Secret {


### PR DESCRIPTION
## Description

Solves the problem where the operator needs to know the admin credentials even if they are provided from a user provided secret or config map.

The operator needs an admin account to communicate with Grafana. The following behaviour applies:

1. If not told otherwise, the operator creates an admin secret and exposes the credentials as env vars to the running (operator) container.
2. The username and password are either taken from `spec.security` or are created randomly.
3. This also applies if `spec.deployment.envFrom` is used to mount external secretes or config maps as env vars.
4. If the user wishes to provide admin credentials from one of those external resources, they *must* set `spec.deployment.skipCreatingAdminAccount` to stop the operator from overriding it.
5. In that case, the operator still needs to know about the admin credentials. So it will search for the relevant values inside all provided external resources.
6. When found it will expose them as env vars to the running (operator) container.

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] This change requires a documentation update 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer

## Verification steps
1. Try the `deploy/examples/env` example and make sure that dashboards can still be created. This should work in cluster (using an image) and when running the operator externally.
