### PR TITLE
allow setting the pod priority class name for the Grafana deployment

### DIFF
--- a/deploy/crds/Grafana.yaml
+++ b/deploy/crds/Grafana.yaml
@@ -121,6 +121,9 @@ spec:
                 skipCreateAdminAccount:
                   type: boolean
                   description: Disable creating a random admin user
+                priorityClassName:
+                  type: string
+                  description: Pod priority class name
             serviceAccount:
               type: object
               properties:

--- a/pkg/apis/integreatly/v1alpha1/grafana_types.go
+++ b/pkg/apis/integreatly/v1alpha1/grafana_types.go
@@ -83,6 +83,7 @@ type GrafanaDeployment struct {
 	TerminationGracePeriodSeconds int64                  `json:"terminationGracePeriodSeconds"`
 	EnvFrom                       []v1.EnvFromSource     `json:"envFrom,omitempty"`
 	SkipCreateAdminAccount        *bool                  `json:"skipCreateAdminAccount,omitempty"`
+	PriorityClassName             string                 `json:"priorityClassName,omitempty"`
 }
 
 // GrafanaIngress provides a means to configure the ingress created

--- a/pkg/controller/model/grafanaDeployment.go
+++ b/pkg/controller/model/grafanaDeployment.go
@@ -150,6 +150,13 @@ func getTerminationGracePeriod(cr *v1alpha1.Grafana) *int64 {
 
 }
 
+func getPodPriorityClassName(cr *v1alpha1.Grafana) string {
+	if cr.Spec.Deployment != nil {
+		return cr.Spec.Deployment.PriorityClassName
+	}
+	return ""
+}
+
 func getTolerations(cr *v1alpha1.Grafana) []v13.Toleration {
 	tolerations := []v13.Toleration{}
 
@@ -493,6 +500,7 @@ func getDeploymentSpec(cr *v1alpha1.Grafana, annotations map[string]string, conf
 				Containers:                    getContainers(cr, configHash, dsHash),
 				ServiceAccountName:            GrafanaServiceAccountName,
 				TerminationGracePeriodSeconds: getTerminationGracePeriod(cr),
+				PriorityClassName:             getPodPriorityClassName(cr),
 			},
 		},
 		Strategy: v1.DeploymentStrategy{


### PR DESCRIPTION
## Description

Allow setting the pod priority class name. Fixes #287 



## Type of change


- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)



## Verification steps
1. Deploy Grafana setting the pod priority class name
2. Ensure the class is correctly set on the deployment & pod
3. Ensure that by default the value is empty
