### PR TITLE
update docs and change base-image to ubi:8

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,11 +1,9 @@
-FROM ubi:8
-
-RUN apk upgrade --update --no-cache
+FROM registry.access.redhat.com/ubi8/ubi:8.0
 
 RUN mkdir -p /opt/jsonnet && chown nobody /opt/jsonnet
 
 USER nobody
 
-ADD grafonnet-lib/grafonnet /opt/jsonnet/grafonnet
+ADD grafonnet-lib/grafonnet/ /opt/jsonnet/grafonnet
 
 ADD build/_output/bin/grafana-operator /usr/local/bin/grafana-operator

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM ubi:8
 
 RUN apk upgrade --update --no-cache
 

--- a/deploy/examples/dashboards/DashboardFromURL.yaml
+++ b/deploy/examples/dashboards/DashboardFromURL.yaml
@@ -7,33 +7,4 @@ metadata:
 spec: 
   name: grafana-dashboard-from-url.json
   url: https://raw.githubusercontent.com/integr8ly/grafana-operator/master/deploy/examples/remote/grafana-dashboard.json
-  json: >
-    {
-      "id": null,
-      "title": "Dashboard repo down",
-      "tags": [],
-      "style": "dark",
-      "timezone": "browser",
-      "editable": true,
-      "hideControls": false,
-      "graphTooltip": 1,
-      "panels": [],
-      "time": {
-        "from": "now-6h",
-        "to": "now"
-      },
-      "timepicker": {
-        "time_options": [],
-        "refresh_intervals": []
-      },
-      "templating": {
-        "list": []
-      },
-      "annotations": {
-        "list": []
-      },
-      "refresh": "5s",
-      "schemaVersion": 17,
-      "version": 0,
-      "links": []
-    }
+  json:

--- a/documentation/dashboards.md
+++ b/documentation/dashboards.md
@@ -1,3 +1,5 @@
+
+
 # Working with dashboards
 
 This document describes how to create dashboards and manage plugins (panels).
@@ -11,7 +13,8 @@ The following properties are accepted in the `spec`:
 * *name*: The filename of the dashboard that gets mounted into a volume in the grafana instance. Not to be confused with `metadata.name`.
 * *json*: Raw json string with the dashboard contents. Check the [official documentation](https://grafana.com/docs/reference/dashboard/#dashboard-json).
 * *jsonnet*: Jsonnet source. The [Grafonnet](https://grafana.github.io/grafonnet-lib/) library is made available automatically and can be imported.
-* *url*: Url address to download a json or jsonnet string with the dashboard contents. This will take priority over the json field in case the download is successful.
+* *url*: Url address to download a json or jsonnet string with the dashboard contents. 
+   * ***Warning***: Ensure that the json field is empty if setting the URL, if both url and json are specified then the json field won't be updated with fetched.
 * *plugins*: A list of plugins required by the dashboard. They will be installed by the operator if not already present.
 * *datasources*: A list of datasources to be used as inputs. See [datasource inputs](#datasource-inputs).
 * *configMapRef*: Import dashboards from config maps. See [config map refreences](#config-map-references).

--- a/documentation/deploy_grafana.md
+++ b/documentation/deploy_grafana.md
@@ -248,7 +248,9 @@ spec:
     ...
     envFrom:                        # Environment variables from Secret or ConfigMap. The key of data becomes the env name.
     ...
-    skipCreateAdminAccount: <bool>  # Skip creating the admin account when providing custom credentials from a secret
+    skipCreateAdminAccount: <bool>  # Skip creating the admin account when providing custom credentials from a secret.
+    ...
+    priorityClassName: <string?     # Assign a priorityClass name to the grafana pod. Empty by default.
 ```
 
 NOTE: Some key's are common to both in securityContext and containerSecurityContext, in that case containerSecurityContext has precendence over securityContext.

--- a/documentation/deploy_grafana.md
+++ b/documentation/deploy_grafana.md
@@ -250,7 +250,7 @@ spec:
     ...
     skipCreateAdminAccount: <bool>  # Skip creating the admin account when providing custom credentials from a secret.
     ...
-    priorityClassName: <string?     # Assign a priorityClass name to the grafana pod. Empty by default.
+    priorityClassName: <string>     # Assign a priorityClass name to the grafana pod. Empty by default.
 ```
 
 NOTE: Some key's are common to both in securityContext and containerSecurityContext, in that case containerSecurityContext has precendence over securityContext.


### PR DESCRIPTION
## Description
Updating documentation to cover recent changes in:
- URL based dashboards <- now require an empty json field to properly fetch dashboards from urls.
- priorityClassName support <-  allows to set a priority class to the grafana deployment pod.

Changing base image to ubi:8 
- easier compatibility with openshift-ci, as well as to keep this consistent with other repos in this org.

## Relevant issues/tickets
<!-- Please include a link to the issue or ticket that applies to this pull request, delete this heading if not relevant -->
#287 #288 

## Type of change

<!-- Please delete options that are not relevant. -->
- [x] Documentation Update
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
N/A 


