### PR TITLE
Add support for TLS settings in AuthGenericOauth

### DIFF
--- a/pkg/apis/integreatly/v1alpha1/grafana_types.go
+++ b/pkg/apis/integreatly/v1alpha1/grafana_types.go
@@ -267,17 +267,21 @@ type GrafanaConfigAuthGitlab struct {
 }
 
 type GrafanaConfigAuthGenericOauth struct {
-	Enabled            *bool  `json:"enabled,omitempty" ini:"enabled"`
-	AllowSignUp        *bool  `json:"allow_sign_up,omitempty" ini:"allow_sign_up"`
-	ClientId           string `json:"client_id,omitempty" ini:"client_id,omitempty"`
-	ClientSecret       string `json:"client_secret,omitempty" ini:"client_secret,omitempty"`
-	Scopes             string `json:"scopes,omitempty" ini:"scopes,omitempty"`
-	AuthUrl            string `json:"auth_url,omitempty" ini:"auth_url,omitempty"`
-	TokenUrl           string `json:"token_url,omitempty" ini:"token_url,omitempty"`
-	ApiUrl             string `json:"api_url,omitempty" ini:"api_url,omitempty"`
-	AllowedDomains     string `json:"allowed_domains,omitempty" ini:"allowed_domains,omitempty"`
-	RoleAttributePath  string `json:"role_attribute_path,omitempty" ini:"role_attribute_path,omitempty"`
-	EmailAttributePath string `json:"email_attribute_path,omitempty" ini:"email_attribute_path,omitempty"`
+	Enabled               *bool  `json:"enabled,omitempty" ini:"enabled"`
+	AllowSignUp           *bool  `json:"allow_sign_up,omitempty" ini:"allow_sign_up"`
+	ClientId              string `json:"client_id,omitempty" ini:"client_id,omitempty"`
+	ClientSecret          string `json:"client_secret,omitempty" ini:"client_secret,omitempty"`
+	Scopes                string `json:"scopes,omitempty" ini:"scopes,omitempty"`
+	AuthUrl               string `json:"auth_url,omitempty" ini:"auth_url,omitempty"`
+	TokenUrl              string `json:"token_url,omitempty" ini:"token_url,omitempty"`
+	ApiUrl                string `json:"api_url,omitempty" ini:"api_url,omitempty"`
+	AllowedDomains        string `json:"allowed_domains,omitempty" ini:"allowed_domains,omitempty"`
+	RoleAttributePath     string `json:"role_attribute_path,omitempty" ini:"role_attribute_path,omitempty"`
+	EmailAttributePath    string `json:"email_attribute_path,omitempty" ini:"email_attribute_path,omitempty"`
+	TLSSkipVerifyInsecure *bool  `json:"tls_skip_verify_insecure,omitempty" ini:"tls_skip_verify_insecure,omitempty"`
+	TLSClientCert         string `json:"tls_client_cert,omitempty" ini:"tls_client_cert,omitempty"`
+	TLSClientKey          string `json:"tls_client_key,omitempty" ini:"tls_client_key,omitempty"`
+	TLSClientCa           string `json:"tls_client_ca,omitempty" ini:"tls_auth_ca,omitempty"`
 }
 
 type GrafanaConfigAuthLdap struct {

--- a/pkg/controller/config/grafanaIni.go
+++ b/pkg/controller/config/grafanaIni.go
@@ -3,10 +3,11 @@ package config
 import (
 	"crypto/sha256"
 	"fmt"
-	"github.com/integr8ly/grafana-operator/v3/pkg/apis/integreatly/v1alpha1"
 	"io"
 	"sort"
 	"strings"
+
+	"github.com/integr8ly/grafana-operator/v3/pkg/apis/integreatly/v1alpha1"
 )
 
 type GrafanaIni struct {
@@ -226,6 +227,10 @@ func (i *GrafanaIni) Write() (string, string) {
 		items = appendStr(items, "allowed_domains", i.cfg.AuthGenericOauth.AllowedDomains)
 		items = appendStr(items, "role_attribute_path", i.cfg.AuthGenericOauth.RoleAttributePath)
 		items = appendStr(items, "email_attribute_path", i.cfg.AuthGenericOauth.EmailAttributePath)
+		items = appendBool(items, "tls_skip_verify_insecure", i.cfg.AuthGenericOauth.TLSSkipVerifyInsecure)
+		items = appendStr(items, "tls_client_cert", i.cfg.AuthGenericOauth.TLSClientCert)
+		items = appendStr(items, "tls_client_key", i.cfg.AuthGenericOauth.TLSClientKey)
+		items = appendStr(items, "tls_client_ca", i.cfg.AuthGenericOauth.TLSClientCa)
 		config["auth.generic_oauth"] = items
 	}
 


### PR DESCRIPTION
## Description
grafana-operator v3.5.0 lacks support for TLS settings in [generic_oauth](https://grafana.com/docs/grafana/latest/auth/generic-oauth/). That's very unfortunate, because there are plenty of companies using self-signed certificates in combination with OIDC (e.g. Keycloak). Thus, there's the need to either feed Grafana with custom certificates or skip TLS verification at all.

The PR adds support for these fields:
* tls_skip_verify_insecure
* tls_client_cert
* tls_client_key
* tls_client_ca

Note: VS Code adjusted formatting a bit, and the change looked reasonable, so I kept it. I hope that's fine.

## Relevant issues/tickets
#192

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
<!-- Tick options that apply, in-code tests are not required but please provide test cases and list steps in "verification steps" with the steps you used to verify this -->
- [ ] This change requires a documentation update 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [X] Verified independently on a cluster by reviewer

## Verification steps
```yaml
  secrets:
    - ca-bundle
  config:
    auth.generic_oauth:
      tls_client_ca: /etc/grafana-secrets/ca-bundle/ca.crt
      tls_skip_verify_insecure: false
      tls_client_cert: /etc/grafana-secrets/ca-bundle/ca.crt
      tls_client_key: /etc/grafana-secrets/ca-bundle/ca.crt
```
I was mostly interested in `tls_client_ca` and `tls_skip_verify_insecure`, so I checked them independently, with real data and actual logging in via OIDC. For the other two, only made sure they appeared in the grafana configmap.

The image I've got is published here: `quay.io/weisdd/grafana-operator:v3.5.0-tls` (SHA256 1dd8d155c84d).
It's a fork from master built with newer Go and Alpine 3.12 as a base image (just didn't like the ub8 image, because the latter is much bigger). Works fine in my environment.