### PR TITLE
Fix-214- use zapper for logging and set log levels

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -116,7 +116,6 @@ func main() {
 	// be propagated through the whole operator, generating
 	// uniform and structured logs.
 
-
 	logf.SetLogger(zap.Logger())
 
 	printVersion()

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -2,8 +2,9 @@ package main
 
 import (
 	"context"
-	"flag"
 	"fmt"
+	"github.com/operator-framework/operator-sdk/pkg/log/zap"
+	"github.com/spf13/pflag"
 	"os"
 	"runtime"
 	"strings"
@@ -52,7 +53,7 @@ func printVersion() {
 }
 
 func init() {
-	flagset := flag.CommandLine
+	flagset := pflag.CommandLine
 	flagset.StringVar(&flagImage, "grafana-image", "", "Overrides the default Grafana image")
 	flagset.StringVar(&flagImageTag, "grafana-image-tag", "", "Overrides the default Grafana image tag")
 	flagset.StringVar(&flagPluginsInitContainerImage, "grafana-plugins-init-container-image", "", "Overrides the default Grafana Plugins Init Container image")
@@ -60,6 +61,7 @@ func init() {
 	flagset.StringVar(&flagNamespaces, "namespaces", "", "Namespaces to scope the interaction of the Grafana operator. Mutually exclusive with --scan-all")
 	flagset.StringVar(&flagJsonnetLocation, "jsonnet-location", "", "Overrides the base path of the jsonnet libraries")
 	flagset.BoolVar(&scanAll, "scan-all", false, "Scans all namespaces for dashboards")
+	flagset.AddFlagSet(zap.FlagSet())
 	flagset.Parse(os.Args[1:])
 }
 
@@ -113,7 +115,9 @@ func main() {
 	// implementing the logr.Logger interface. This logger will
 	// be propagated through the whole operator, generating
 	// uniform and structured logs.
-	logf.SetLogger(logf.ZapLogger(false))
+
+
+	logf.SetLogger(zap.Logger())
 
 	printVersion()
 
@@ -144,7 +148,7 @@ func main() {
 	var dashboardNamespaces = []string{namespace}
 	if scanAll {
 		dashboardNamespaces = []string{""}
-		log.Info("Scanning for dashboards in all namespaces")
+		log.V(1).Info("Scanning for dashboards in all namespaces")
 	}
 
 	if flagNamespaces != "" {
@@ -153,7 +157,7 @@ func main() {
 			fmt.Fprint(os.Stderr, "--namespaces provided but no valid namespaces in list")
 			os.Exit(1)
 		}
-		log.Info(fmt.Sprintf("Scanning for dashboards in the following namespaces: [%s]", strings.Join(dashboardNamespaces, ",")))
+		log.V(1).Info(fmt.Sprintf("Scanning for dashboards in the following namespaces: [%s]", strings.Join(dashboardNamespaces, ",")))
 	}
 
 	// Get a config to talk to the apiserver
@@ -176,7 +180,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	log.Info("Registering Components.")
+	log.V(1).Info("Registering Components.")
 
 	// Starting the resource auto-detection for the grafana controller
 	autodetect, err := common.NewAutoDetect(mgr)
@@ -214,11 +218,12 @@ func main() {
 		},
 	}
 	_, err = metrics.CreateMetricsService(context.TODO(), cfg, servicePorts)
+
 	if err != nil {
 		log.Error(err, "error starting metrics service")
 	}
 
-	log.Info("Starting the Cmd.")
+	log.V(1).Info("Starting the Cmd.")
 
 	signalHandler := signals.SetupSignalHandler()
 

--- a/documentation/deploy_grafana.md
+++ b/documentation/deploy_grafana.md
@@ -115,13 +115,16 @@ The operator accepts a number of flags that can be passed in the `args` section 
 
 * `--grafonnet-location`: overrides the location of the grafonnet library. Defaults to `/opt/grafonnet-lib`. Only useful when running the operator locally.
 
-* `--scan-all`: watch for dashboards in all namespaces. This requires the the operator service account to have cluster wide permissions to `get`, `list`, `update` and `watch` dashboards. See `deploy/cluster_roles`.
+* `--scan-all`: watch for dashboards in all namespaces. This requires the operator service account to have cluster wide permissions to `get`, `list`, `update` and `watch` dashboards. See `deploy/cluster_roles`.
 
 * `--namespaces`: watch for dashboards in a list of namespaces. Mutually exclusive with `--scan-all`.
 
+* `--zap-level=n`: set the logging level for the operator, leaving out this flag will only log Errors and error related info, current options are:
+**  `--zap-level=1`: show all Info level logs
+
 See `deploy/operator.yaml` for an example.
 
-If using the automated Ansible installer see the [grafana-operator-namespace-resources.yaml - Parameters](../deploy/ansible/README.md#parameters-1) for the equivlant parameters.
+If using the automated Ansible installer see the [grafana-operator-namespace-resources.yaml - Parameters](../deploy/ansible/README.md#parameters-1) for the equivalent parameters.
 
 ## Deploying Grafana
 

--- a/documentation/deploy_grafana.md
+++ b/documentation/deploy_grafana.md
@@ -120,7 +120,7 @@ The operator accepts a number of flags that can be passed in the `args` section 
 * `--namespaces`: watch for dashboards in a list of namespaces. Mutually exclusive with `--scan-all`.
 
 * `--zap-level=n`: set the logging level for the operator, leaving out this flag will only log Errors and error related info, current options are:
-**  `--zap-level=1`: show all Info level logs
+    - `--zap-level=1`: show all Info level logs
 
 See `deploy/operator.yaml` for an example.
 

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/openshift/api v3.9.0+incompatible
 	github.com/operator-framework/operator-sdk v0.18.2
 	github.com/pkg/errors v0.9.1
+	github.com/spf13/pflag v1.0.5
 	k8s.io/api v0.18.2
 	k8s.io/apimachinery v0.18.2
 	k8s.io/client-go v12.0.0+incompatible

--- a/pkg/controller/common/clusterActions.go
+++ b/pkg/controller/common/clusterActions.go
@@ -78,7 +78,7 @@ func (i *ClusterActionRunner) RunAll(desiredState DesiredClusterState) error {
 			i.log.Info(fmt.Sprintf("(%5d) %10s %s", index, "FAILED", msg))
 			return err
 		}
-		i.log.Info(fmt.Sprintf("(%5d) %10s %s", index, "SUCCESS", msg))
+		i.log.V(1).Info(fmt.Sprintf("(%5d) %10s %s", index, "SUCCESS", msg))
 	}
 
 	return nil
@@ -100,10 +100,11 @@ func (i *ClusterActionRunner) exposeSecret(ns string, ref *v14.SecretEnvSource, 
 		for secretKey, secretValue := range secret.Data {
 			if exposedVar == secretKey {
 				os.Setenv(secretKey, string(secretValue))
-				i.log.Info(fmt.Sprintf("found value for %s in secret %s", exposedVar, ref.Name))
+				i.log.V(1).Info("found value for %s in secret %s", exposedVar, ref.Name)
 			}
 		}
 	}
+
 	return nil
 }
 
@@ -123,7 +124,7 @@ func (i *ClusterActionRunner) exposeConfigMap(ns string, ref *v14.ConfigMapEnvSo
 		for configMapKey, configMapValue := range configMap.Data {
 			if exposedVar == configMapKey {
 				os.Setenv(configMapKey, string(configMapValue))
-				i.log.Info(fmt.Sprintf("found value for %s in config map %s", exposedVar, ref.Name))
+				i.log.V(1).Info("found value for %s in config map %s", exposedVar, ref.Name)
 			}
 		}
 	}

--- a/pkg/controller/common/clusterActions.go
+++ b/pkg/controller/common/clusterActions.go
@@ -3,6 +3,7 @@ package common
 import (
 	"context"
 	stdErr "errors"
+	"fmt"
 	"github.com/go-logr/logr"
 	"github.com/integr8ly/grafana-operator/v3/pkg/controller/model"
 	v13 "github.com/openshift/api/route/v1"
@@ -74,10 +75,10 @@ func (i *ClusterActionRunner) RunAll(desiredState DesiredClusterState) error {
 	for index, action := range desiredState {
 		msg, err := action.Run(i)
 		if err != nil {
-			i.log.V(1).Info("(%5d) %10s %s", index, "FAILED", msg)
+			i.log.V(1).Info(fmt.Sprintf("(%5d) %10s %s", index, "FAILED", msg))
 			return err
 		}
-		i.log.V(1).Info("(%5d) %10s %s", index, "SUCCESS", msg)
+		i.log.V(1).Info(fmt.Sprintf("(%5d) %10s %s", index, "SUCCESS", msg))
 	}
 
 	return nil

--- a/pkg/controller/common/clusterActions.go
+++ b/pkg/controller/common/clusterActions.go
@@ -3,7 +3,6 @@ package common
 import (
 	"context"
 	stdErr "errors"
-	"fmt"
 	"github.com/go-logr/logr"
 	"github.com/integr8ly/grafana-operator/v3/pkg/controller/model"
 	v13 "github.com/openshift/api/route/v1"
@@ -75,10 +74,10 @@ func (i *ClusterActionRunner) RunAll(desiredState DesiredClusterState) error {
 	for index, action := range desiredState {
 		msg, err := action.Run(i)
 		if err != nil {
-			i.log.Info(fmt.Sprintf("(%5d) %10s %s", index, "FAILED", msg))
+			i.log.V(1).Info("(%5d) %10s %s", index, "FAILED", msg)
 			return err
 		}
-		i.log.V(1).Info(fmt.Sprintf("(%5d) %10s %s", index, "SUCCESS", msg))
+		i.log.V(1).Info("(%5d) %10s %s", index, "SUCCESS", msg)
 	}
 
 	return nil

--- a/pkg/controller/grafana/grafana_controller.go
+++ b/pkg/controller/grafana/grafana_controller.go
@@ -102,7 +102,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler, autodetectChannel chan sch
 					log.Error(err, fmt.Sprintf("error adding secondary watch for %v", common.RouteKind))
 				} else {
 					cfg.AddConfigItem(config.ConfigRouteWatch, true)
-					log.Info(fmt.Sprintf("added secondary watch for %v", common.RouteKind))
+					log.V(1).Info("added secondary watch for %v", common.RouteKind)
 				}
 			}
 		}
@@ -295,7 +295,7 @@ func (r *ReconcileGrafana) manageSuccess(cr *grafanav1alpha1.Grafana, state *com
 
 	common.ControllerEvents <- controllerState
 
-	log.Info("desired cluster state met")
+	log.V(1).Info("desired cluster state met")
 
 	return reconcile.Result{RequeueAfter: config.RequeueDelay}, nil
 }

--- a/pkg/controller/grafana/grafana_reconciler.go
+++ b/pkg/controller/grafana/grafana_reconciler.go
@@ -333,12 +333,12 @@ func (i *GrafanaReconciler) reconcilePlugins(cr *v1alpha1.Grafana, plugins v1alp
 
 	for _, plugin := range plugins {
 		if i.Plugins.PluginExists(plugin) == false {
-			log.Info(fmt.Sprintf("invalid plugin: %s@%s", plugin.Name, plugin.Version))
+			log.V(1).Info("invalid plugin: %s@%s", plugin.Name, plugin.Version)
 			failedPlugins = append(failedPlugins, plugin)
 			continue
 		}
 
-		log.Info(fmt.Sprintf("installing plugin: %s@%s", plugin.Name, plugin.Version))
+		log.V(1).Info("installing plugin: %s@%s", plugin.Name, plugin.Version)
 		validPlugins = append(validPlugins, plugin)
 	}
 

--- a/pkg/controller/grafana/grafonnet_utils.go
+++ b/pkg/controller/grafana/grafonnet_utils.go
@@ -57,7 +57,7 @@ func reconcileConfigMaps(cr *grafanav1alpha1.Grafana, r *ReconcileGrafana) error
 			if err != nil {
 				return err
 			}
-			log.Info(fmt.Sprintf("imported jsonnet library %v", filePath))
+			log.V(1).Info(fmt.Sprintf("imported jsonnet library %v", filePath))
 		}
 	}
 	return nil

--- a/pkg/controller/grafana/pluginsHelper.go
+++ b/pkg/controller/grafana/pluginsHelper.go
@@ -115,7 +115,7 @@ func (h *PluginsHelperImpl) FilterPlugins(cr *grafanav1alpha1.Grafana, requested
 		// New plugin
 		if cr.Status.InstalledPlugins.HasSomeVersionOf(&plugin) == false {
 			filteredPlugins = append(filteredPlugins, plugin)
-			log.Info(fmt.Sprintf("installing plugin %s@%s", plugin.Name, plugin.Version))
+			log.V(1).Info(fmt.Sprintf("installing plugin %s@%s", plugin.Name, plugin.Version))
 			pluginsUpdated = true
 			continue
 		}

--- a/pkg/controller/grafana/pluginsHelper.go
+++ b/pkg/controller/grafana/pluginsHelper.go
@@ -97,7 +97,7 @@ func (h *PluginsHelperImpl) FilterPlugins(cr *grafanav1alpha1.Grafana, requested
 		// Don't allow to install multiple versions of the same plugin
 		if filteredPlugins.HasSomeVersionOf(&plugin) == true {
 			installedVersion := filteredPlugins.GetInstalledVersionOf(&plugin)
-			log.Info(fmt.Sprintf("not installing version %s of %s because %s is already installed", plugin.Version, plugin.Name, installedVersion.Version))
+			log.V(1).Info(fmt.Sprintf("not installing version %s of %s because %s is already installed", plugin.Version, plugin.Name, installedVersion.Version))
 			continue
 		}
 
@@ -130,7 +130,7 @@ func (h *PluginsHelperImpl) FilterPlugins(cr *grafanav1alpha1.Grafana, requested
 			requested.VersionsOf(&plugin) == 1 {
 			installedVersion := cr.Status.InstalledPlugins.GetInstalledVersionOf(&plugin)
 			filteredPlugins = append(filteredPlugins, plugin)
-			log.Info(fmt.Sprintf("changing version of plugin %s form %s to %s", plugin.Name, installedVersion.Version, plugin.Version))
+			log.V(1).Info(fmt.Sprintf("changing version of plugin %s form %s to %s", plugin.Name, installedVersion.Version, plugin.Version))
 			pluginsUpdated = true
 			continue
 		}

--- a/pkg/controller/grafanadashboard/dashboard_controller.go
+++ b/pkg/controller/grafanadashboard/dashboard_controller.go
@@ -80,7 +80,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler, namespace string) error {
 
 	go func() {
 		for range ticker.C {
-			log.Info("running periodic dashboard resync")
+			log.V(1).Info("running periodic dashboard resync")
 			sendEmptyRequest()
 		}
 	}()
@@ -113,7 +113,7 @@ func (r *ReconcileGrafanaDashboard) Reconcile(request reconcile.Request) (reconc
 
 	// If Grafana is not running there is no need to continue
 	if !r.state.GrafanaReady {
-		log.Info("no grafana instance available")
+		log.Error(fmt.Errorf("no grafana instance available"),"")
 		return reconcile.Result{Requeue: false}, nil
 	}
 
@@ -341,7 +341,7 @@ func (r *ReconcileGrafanaDashboard) manageSuccess(dashboard *grafanav1alpha1.Gra
 		dashboard.Namespace,
 		dashboard.Name)
 	r.recorder.Event(dashboard, "Normal", "Success", msg)
-	log.Info(msg)
+	log.V(1).Info(msg)
 	r.config.AddDashboard(dashboard, folderId, folderName)
 	r.config.SetPluginsFor(dashboard)
 }

--- a/pkg/controller/grafanadashboard/dashboard_controller.go
+++ b/pkg/controller/grafanadashboard/dashboard_controller.go
@@ -113,7 +113,7 @@ func (r *ReconcileGrafanaDashboard) Reconcile(request reconcile.Request) (reconc
 
 	// If Grafana is not running there is no need to continue
 	if !r.state.GrafanaReady {
-		log.Error(fmt.Errorf("no grafana instance available"),"")
+		log.Error(fmt.Errorf("no grafana instance available"), "")
 		return reconcile.Result{Requeue: false}, nil
 	}
 

--- a/pkg/controller/grafanadashboard/dashboard_controller.go
+++ b/pkg/controller/grafanadashboard/dashboard_controller.go
@@ -113,7 +113,7 @@ func (r *ReconcileGrafanaDashboard) Reconcile(request reconcile.Request) (reconc
 
 	// If Grafana is not running there is no need to continue
 	if !r.state.GrafanaReady {
-		log.Error(fmt.Errorf("no grafana instance available"), "")
+		log.V(1).Info("no grafana instance available")
 		return reconcile.Result{Requeue: false}, nil
 	}
 

--- a/pkg/controller/grafanadashboard/dashboard_controller.go
+++ b/pkg/controller/grafanadashboard/dashboard_controller.go
@@ -63,7 +63,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler, namespace string) error {
 	// Watch for changes to primary resource GrafanaDashboard
 	err = c.Watch(&source.Kind{Type: &grafanav1alpha1.GrafanaDashboard{}}, &handler.EnqueueRequestForObject{})
 	if err == nil {
-		log.Info("Starting dashboard controller")
+		log.V(1).Info("Starting dashboard controller")
 	}
 
 	ref := r.(*ReconcileGrafanaDashboard)
@@ -140,7 +140,7 @@ func (r *ReconcileGrafanaDashboard) Reconcile(request reconcile.Request) (reconc
 
 		if errors.IsNotFound(err) {
 			// If some dashboard has been deleted, then always re sync the world
-			log.Info(fmt.Sprintf("deleting dashboard %v/%v", request.Namespace, request.Name))
+			log.V(1).Info(fmt.Sprintf("deleting dashboard %v/%v", request.Namespace, request.Name))
 			return r.reconcileDashboards(request, client)
 		}
 		// Error reading the object - requeue the request.
@@ -150,7 +150,7 @@ func (r *ReconcileGrafanaDashboard) Reconcile(request reconcile.Request) (reconc
 	// If the dashboard does not match the label selectors then we ignore it
 	cr := instance.DeepCopy()
 	if !r.isMatch(cr) {
-		log.Info(fmt.Sprintf("dashboard %v/%v found but selectors do not match",
+		log.V(1).Info(fmt.Sprintf("dashboard %v/%v found but selectors do not match",
 			cr.Namespace, cr.Name))
 		return reconcile.Result{}, nil
 	}
@@ -222,14 +222,13 @@ func (r *ReconcileGrafanaDashboard) reconcileDashboards(request reconcile.Reques
 		if !inNamespace(dashboard) {
 			dashboardsToDelete = append(dashboardsToDelete, dashboard)
 		}
-
 	}
 
 	// Process new/updated dashboards
 	for _, dashboard := range namespaceDashboards.Items {
 		// Is this a dashboard we care about (matches the label selectors)?
 		if !r.isMatch(&dashboard) {
-			log.Info(fmt.Sprintf("dashboard %v/%v found but selectors do not match",
+			log.V(1).Info(fmt.Sprintf("dashboard %v/%v found but selectors do not match",
 				dashboard.Namespace, dashboard.Name))
 			continue
 		}
@@ -280,7 +279,7 @@ func (r *ReconcileGrafanaDashboard) reconcileDashboards(request reconcile.Reques
 			}
 
 			if matchesNamespaceLabels == false {
-				log.Info(fmt.Sprintf("dashboard %v skipped because the namespace labels do not match", dashboard.Name))
+				log.V(1).Info(fmt.Sprintf("dashboard %v skipped because the namespace labels do not match", dashboard.Name))
 				continue
 			}
 		}
@@ -306,7 +305,7 @@ func (r *ReconcileGrafanaDashboard) reconcileDashboards(request reconcile.Reques
 					*status.Message))
 			}
 
-			log.Info(fmt.Sprintf("delete result was %v", *status.Message))
+			log.V(1).Info(fmt.Sprintf("delete result was %v", *status.Message))
 
 			r.config.RemovePluginsFor(dashboard.Namespace, dashboard.Name)
 			r.config.RemoveDashboard(dashboard.Namespace, dashboard.Name)
@@ -321,7 +320,7 @@ func (r *ReconcileGrafanaDashboard) reconcileDashboards(request reconcile.Reques
 			// Check for empty managed folders (namespace-named) and delete obsolete ones
 			if dashboard.FolderName == "" || dashboard.FolderName == dashboard.Namespace {
 				if safe := grafanaClient.SafeToDelete(knownDashboards, dashboard.FolderId); !safe {
-					log.Info("folder cannot be deleted as it's being used by other dashboards")
+					log.V(1).Info("folder cannot be deleted as it's being used by other dashboards")
 					break
 				}
 				if err = grafanaClient.DeleteFolder(dashboard.FolderId); err != nil {

--- a/pkg/controller/grafanadashboard/dashboard_pipeline.go
+++ b/pkg/controller/grafanadashboard/dashboard_pipeline.go
@@ -52,7 +52,6 @@ func NewDashboardPipeline(client client.Client, dashboard *v1alpha1.GrafanaDashb
 	}
 }
 
-
 func (r *DashboardPipelineImpl) ProcessDashboard(knownHash string, folderId *int64, folderName string) ([]byte, error) {
 	err := r.obtainJson()
 	if err != nil {

--- a/pkg/controller/grafanadashboard/dashboard_pipeline.go
+++ b/pkg/controller/grafanadashboard/dashboard_pipeline.go
@@ -52,6 +52,7 @@ func NewDashboardPipeline(client client.Client, dashboard *v1alpha1.GrafanaDashb
 	}
 }
 
+
 func (r *DashboardPipelineImpl) ProcessDashboard(knownHash string, folderId *int64, folderName string) ([]byte, error) {
 	err := r.obtainJson()
 	if err != nil {
@@ -253,13 +254,13 @@ func (r *DashboardPipelineImpl) resolveDatasources() error {
 	for _, input := range r.Dashboard.Spec.Datasources {
 		if input.DatasourceName == "" || input.InputName == "" {
 			msg := fmt.Sprintf("invalid datasource input rule, input or datasource empty")
-			r.Logger.Info(msg)
+			r.Logger.V(1).Info(msg)
 			return errors.New(msg)
 		}
 
 		searchValue := fmt.Sprintf("${%s}", input.InputName)
 		currentJson = strings.ReplaceAll(currentJson, searchValue, input.DatasourceName)
-		r.Logger.Info(fmt.Sprintf("resolving input %s to %s", input.InputName, input.DatasourceName))
+		r.Logger.V(1).Info(fmt.Sprintf("resolving input %s to %s", input.InputName, input.DatasourceName))
 	}
 
 	r.JSON = currentJson

--- a/pkg/controller/grafanadashboard/grafana_client.go
+++ b/pkg/controller/grafanadashboard/grafana_client.go
@@ -414,7 +414,7 @@ func (r *GrafanaClientImpl) DeleteFolder(deleteID *int64) error {
 	}
 
 	err = json.Unmarshal(data, &response)
-	log.Info(fmt.Sprintf("delete result was %v", *response.Message))
+	log.V(1).Info(fmt.Sprintf("delete result was %v", *response.Message))
 
 	return err
 }

--- a/pkg/controller/grafanadatasource/datasource_controller.go
+++ b/pkg/controller/grafanadatasource/datasource_controller.go
@@ -85,7 +85,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler, namespace string) error {
 
 	go func() {
 		for range ticker.C {
-			log.Info("running periodic datasource resync")
+			log.V(1).Info("running periodic datasource resync")
 			sendEmptyRequest()
 		}
 	}()

--- a/pkg/controller/grafanadatasource/datasource_controller.go
+++ b/pkg/controller/grafanadatasource/datasource_controller.go
@@ -126,7 +126,7 @@ func (r *ReconcileGrafanaDataSource) Reconcile(request reconcile.Request) (recon
 	}
 
 	if currentState.KnownDataSources == nil {
-		log.Info(fmt.Sprintf("no datasources configmap found"))
+		log.V(1).Info(fmt.Sprintf("no datasources configmap found"))
 		return reconcile.Result{Requeue: false}, nil
 	}
 
@@ -170,7 +170,7 @@ func (r *ReconcileGrafanaDataSource) reconcileDataSources(state *common.DataSour
 
 	// apply dataSourcesToDelete
 	for _, ds := range dataSourcesToDelete {
-		log.Info(fmt.Sprintf("deleting datasource %v", ds))
+		log.V(1).Info(fmt.Sprintf("deleting datasource %v", ds))
 		if state.KnownDataSources.Data != nil {
 			delete(state.KnownDataSources.Data, ds)
 		}
@@ -269,7 +269,7 @@ func (r *ReconcileGrafanaDataSource) manageError(datasource *grafanav1alpha1.Gra
 // is updated
 func (r *ReconcileGrafanaDataSource) manageSuccess(datasources []grafanav1alpha1.GrafanaDataSource) {
 	for _, datasource := range datasources {
-		log.Info(fmt.Sprintf("datasource %v/%v successfully imported",
+		log.V(1).Info(fmt.Sprintf("datasource %v/%v successfully imported",
 			datasource.Namespace,
 			datasource.Name))
 


### PR DESCRIPTION
## Description
- Adding zapper as the new logger
- introducing log levels 
  - no `--zap-level` = only errors and failed reconcile steps
  - `-zap-level=1` = Info level logging
  - `--zap-level=2` = Debug level logging <- To be added

## Relevant issues/tickets
#214 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
<!-- Tick options that apply, in-code tests are not required but please provide test cases and list steps in "verification steps" with the steps you used to verify this -->
- [x] This change requires a documentation update 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer

## Verification steps
<!-- Please include a series of steps to verify that the functionality/bug fix works, ideally the steps you used to test these changes(if applicable, if not, delete this section)-->
1. Run the operator using 
`operator-sdk run local --watch-namespace=grafana --operator-flags='--zap-level=1'`
and confirm that the output is as normal/expected or the same as that from master
2. Run the operator using
`operator-sdk run local --watch-namespace=grafana`
and confirm that only error/failed reconcile info is logged (apart from initial logging for versions etc.)
