### PR TITLE
close idle HTTP client connections at the end of a reconciliation run

### DIFF
--- a/pkg/controller/grafanadashboard/dashboard_controller.go
+++ b/pkg/controller/grafanadashboard/dashboard_controller.go
@@ -121,6 +121,7 @@ func (r *ReconcileGrafanaDashboard) Reconcile(request reconcile.Request) (reconc
 	if err != nil {
 		return reconcile.Result{RequeueAfter: config.RequeueDelay}, nil
 	}
+	defer client.Shutdown()
 
 	// Initial request?
 	if request.Name == "" {

--- a/pkg/controller/grafanadashboard/grafana_client.go
+++ b/pkg/controller/grafanadashboard/grafana_client.go
@@ -62,6 +62,7 @@ type GrafanaClient interface {
 	CreateOrUpdateFolder(folderName string) (GrafanaFolderResponse, error)
 	DeleteFolder(folderID *int64) error
 	SafeToDelete(dashboards []*v1alpha1.GrafanaDashboardRef, folderID *int64) bool
+	Shutdown()
 }
 
 type GrafanaClientImpl struct {
@@ -426,4 +427,8 @@ func (r *GrafanaClientImpl) SafeToDelete(dashlist []*v1alpha1.GrafanaDashboardRe
 		}
 	}
 	return true
+}
+
+func (r *GrafanaClientImpl) Shutdown() {
+	r.client.CloseIdleConnections()
 }


### PR DESCRIPTION
## Description
During every reconciliation run, the operator opens a new Grafana API connection to sync the managed folders. These connections are kept alive indefinitely, eventually exhausting the resources available.

I have a bare metal `kubeadm` cluster, and I've installed `grafana-operator` using the [manual method](https://github.com/integr8ly/grafana-operator/blob/master/documentation/deploy_grafana.md#manual-procedure). Everything seemed to run normally, but after a few days, the operator pod started logging messages like this:

    {"level":"error","ts":1603676475.339174,"logger":"controller_grafanadashboard","msg":"failed to get or create namespace folder %v for dashboard %v with error %v","monitoring":"","error":"Get http://admin:***@10.108.29.90:3000/api/folders: dial tcp 10.108.29.90:3000: connect: cannot assign requested address","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/home/travis/gopath/pkg/mod/github.com/go-logr/zapr@v0.1.1/zapr.go:128\ngithub.com/integr8ly/grafana-operator/v3/pkg/controller/grafanadashboard.(*ReconcileGrafanaDashboard).reconcileDashboards\n\tgrafana-operator/pkg/controller/grafanadashboard/dashboard_controller.go:245\ngithub.com/integr8ly/grafana-operator/v3/pkg/controller/grafanadashboard.(*ReconcileGrafanaDashboard).Reconcile\n\tgrafana-operator/pkg/controller/grafanadashboard/dashboard_controller.go:127\ngithub.com/integr8ly/grafana-operator/v3/pkg/controller/grafanadashboard.add.func1\n\tgrafana-operator/pkg/controller/grafanadashboard/dashboard_controller.go:78\ngithub.com/integr8ly/grafana-operator/v3/pkg/controller/grafanadashboard.add.func2\n\tgrafana-operator/pkg/controller/grafanadashboard/dashboard_controller.go:84"}

When I ran `netstat` in the Grafana pod, it listed about 28500 open connections. The error cleared up after restarting the Grafana pod, but connections were leaking steadily, at a rate of one connection every 10 seconds.

The changes attempt to ensure that every `GrafanaClient` instance created is cleaned up before going out of scope, closing idle connections that would otherwise be kept alive for later reuse - which doesn't happen, as the `GrafanaClient` instance is forgotten about and the next reconciliation run will create a brand new instance. Or so I think. Please review thoroughly, this is the first time I've ever gone anywhere near Go code.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
<!-- Tick options that apply, in-code tests are not required but please provide test cases and list steps in "verification steps" with the steps you used to verify this -->
- [ ] This change requires a documentation update 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer

## Verification steps
The verification itself is simple: run `netstat | wc -l` in the `grafana-deployment` pod a few times, with a couple minutes between the runs. The number should rise steadily without the changes, and stay approximately constant with them.

I'm not sure if there are other contributing factors that are needed for the problem to manifest though... for example, if the operator talks to the Grafana instance via an Ingress, the proxy may forcefully close idle connections after a while, mitigating the issue.