### PR TITLE
Adding default fsGroup to PodSecurityContext

### DIFF
--- a/deploy/crds/Grafana.yaml
+++ b/deploy/crds/Grafana.yaml
@@ -29,6 +29,13 @@ spec:
               items:
                 type: string
                 description: Secret to be mounted as volume into the grafana deployment
+            dataStorage:
+              accessModes:
+                type: string
+                description: Access mode for this volume
+              size:
+                type: string
+                description: Size of this volume in Gi's
             configMaps:
               type: array
               items:

--- a/pkg/controller/model/grafanaDeployment.go
+++ b/pkg/controller/model/grafanaDeployment.go
@@ -73,7 +73,10 @@ func getAffinities(cr *v1alpha1.Grafana) *v13.Affinity {
 }
 
 func getSecurityContext(cr *v1alpha1.Grafana) *v13.PodSecurityContext {
-	var securityContext = v13.PodSecurityContext{}
+	var fsGroup int64 = 472 //grafana GID in docker image
+	var securityContext = v13.PodSecurityContext{
+		FSGroup: &fsGroup,
+	}
 	if cr.Spec.Deployment != nil && cr.Spec.Deployment.SecurityContext != nil {
 		securityContext = *cr.Spec.Deployment.SecurityContext
 	}


### PR DESCRIPTION
## Description
Sets a default `fsGroup` in the Pod `securityContext` to allow a PVC to be mounted and used for persistence with `dataStorage`

## Relevant issues/tickets
https://github.com/integr8ly/grafana-operator/issues/300

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
<!-- Tick options that apply, in-code tests are not required but please provide test cases and list steps in "verification steps" with the steps you used to verify this -->
- [ ] This change requires a documentation update 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer

## Verification steps
<!-- Please include a series of steps to verify that the functionality/bug fix works, ideally the steps you used to test these changes(if applicable, if not, delete this section)-->
Deploy a minimally viable Grafana with a `dataStorage` spec, such as:
```
apiVersion: integreatly.org/v1alpha1
kind: Grafana
metadata:
  name: grafana
  namespace: grafana
spec:
  dataStorage:
    accessModes:
    - ReadWriteOnce
    size: 10Gi
    class: standard
  dashboardLabelSelector:
    - matchExpressions:
      - {key: app, operator: In, values: [grafana]}
```
and validate that the Grafana Pod starts up successfully with the PVC mounted. The current release of `grafana-operator` will fail to start as noted in https://github.com/integr8ly/grafana-operator/issues/300

I only really saw e2e tests, which do not currently set any `dataStorage`. I'd be more than happy to add that if requested but I know PVCs can be cumbersome sometimes