### PR TITLE
 Reuse TCP transport to prevent connection leak

### DIFF
--- a/pkg/controller/grafana/grafana_controller.go
+++ b/pkg/controller/grafana/grafana_controller.go
@@ -286,7 +286,7 @@ func (r *ReconcileGrafana) manageSuccess(cr *grafanav1alpha1.Grafana, state *com
 	}
 
 	if cr.Spec.Client != nil && cr.Spec.Client.TimeoutSeconds != nil {
-		seconds := DefaultClientTimeoutSeconds
+		seconds := *cr.Spec.Client.TimeoutSeconds
 		if seconds < 0 {
 			seconds = DefaultClientTimeoutSeconds
 		}

--- a/pkg/controller/grafanadashboard/dashboard_controller.go
+++ b/pkg/controller/grafanadashboard/dashboard_controller.go
@@ -122,7 +122,6 @@ func (r *ReconcileGrafanaDashboard) Reconcile(request reconcile.Request) (reconc
 	if err != nil {
 		return reconcile.Result{RequeueAfter: config.RequeueDelay}, nil
 	}
-	defer client.Shutdown()
 
 	// Initial request?
 	if request.Name == "" {

--- a/pkg/controller/grafanadashboard/grafana_client.go
+++ b/pkg/controller/grafanadashboard/grafana_client.go
@@ -2,7 +2,6 @@ package grafanadashboard
 
 import (
 	"bytes"
-	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -78,15 +77,9 @@ func setHeaders(req *http.Request) {
 	req.Header.Set("User-Agent", "grafana-operator")
 }
 
-func NewGrafanaClient(url, user, password string, timeoutSeconds time.Duration) GrafanaClient {
-	transport := http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true,
-		},
-	}
-
+func NewGrafanaClient(url, user, password string, transport *http.Transport, timeoutSeconds time.Duration) GrafanaClient {
 	client := &http.Client{
-		Transport: &transport,
+		Transport: transport,
 		Timeout:   time.Second * timeoutSeconds,
 	}
 

--- a/pkg/controller/grafanadashboard/grafana_client.go
+++ b/pkg/controller/grafanadashboard/grafana_client.go
@@ -5,11 +5,12 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"github.com/integr8ly/grafana-operator/v3/pkg/apis/integreatly/v1alpha1"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"time"
+
+	"github.com/integr8ly/grafana-operator/v3/pkg/apis/integreatly/v1alpha1"
 )
 
 const (
@@ -62,7 +63,6 @@ type GrafanaClient interface {
 	CreateOrUpdateFolder(folderName string) (GrafanaFolderResponse, error)
 	DeleteFolder(folderID *int64) error
 	SafeToDelete(dashboards []*v1alpha1.GrafanaDashboardRef, folderID *int64) bool
-	Shutdown()
 }
 
 type GrafanaClientImpl struct {
@@ -427,8 +427,4 @@ func (r *GrafanaClientImpl) SafeToDelete(dashlist []*v1alpha1.GrafanaDashboardRe
 		}
 	}
 	return true
-}
-
-func (r *GrafanaClientImpl) Shutdown() {
-	r.client.CloseIdleConnections()
 }


### PR DESCRIPTION
Signed-off-by: H.Muraoka <hiroshi-muraoka@cybozu.co.jp>

## Description

The conntrack table on which a grafana opeartor v3.6.0 is running is filled with too many(~35k) entries as shown below.

<img width="651" alt="conntrack_entries" src="https://user-images.githubusercontent.com/5456898/100421840-80f60300-30cc-11eb-9e31-7366060c5606.PNG">

I think this is caused by the dashboard operator, which creates an http client but leaves it unclosed every time it runs a reconciliation loop.

[The golang official document](https://golang.org/pkg/net/http/#Client) indicates that:

> The Client's Transport typically has internal state (cached TCP connections), so Clients should be reused instead of created as needed. Clients are safe for concurrent use by multiple goroutines.

This PR fixes the connection leak by reusing the TCP connection and fixes [the client timeout assignment logic](https://github.com/integr8ly/grafana-operator/blob/14a623c4b4468f5321c2a75004434196bf4d19ff/pkg/controller/grafana/grafana_controller.go#L289), which is probably a bug, as well.

## Relevant issues/tickets
<!-- Please include a link to the issue or ticket that applies to this pull request, delete this heading if not relevant -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
<!-- Tick options that apply, in-code tests are not required but please provide test cases and list steps in "verification steps" with the steps you used to verify this -->
- [ ] This change requires a documentation update 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer

## Verification steps
<!-- Please include a series of steps to verify that the functionality/bug fix works, ideally the steps you used to test these changes(if applicable, if not, delete this section)-->

Go to the node on which a grafana-operator is running, and execute the following:

```
$ sudo conntrack -L | wc -l
```
