### PR TITLE
Format strings in some log messages are not replaced

### DIFF
--- a/pkg/controller/common/clusterActions.go
+++ b/pkg/controller/common/clusterActions.go
@@ -100,7 +100,7 @@ func (i *ClusterActionRunner) exposeSecret(ns string, ref *v14.SecretEnvSource, 
 		for secretKey, secretValue := range secret.Data {
 			if exposedVar == secretKey {
 				os.Setenv(secretKey, string(secretValue))
-				i.log.V(1).Info("found value for %s in secret %s", exposedVar, ref.Name)
+				i.log.V(1).Info(fmt.Sprintf("found value for %s in secret %s", exposedVar, ref.Name))
 			}
 		}
 	}
@@ -124,7 +124,7 @@ func (i *ClusterActionRunner) exposeConfigMap(ns string, ref *v14.ConfigMapEnvSo
 		for configMapKey, configMapValue := range configMap.Data {
 			if exposedVar == configMapKey {
 				os.Setenv(configMapKey, string(configMapValue))
-				i.log.V(1).Info("found value for %s in config map %s", exposedVar, ref.Name)
+				i.log.V(1).Info(fmt.Sprintf("found value for %s in config map %s", exposedVar, ref.Name))
 			}
 		}
 	}

--- a/pkg/controller/common/clusterActions.go
+++ b/pkg/controller/common/clusterActions.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	stdErr "errors"
 	"fmt"
+	"os"
+
 	"github.com/go-logr/logr"
 	"github.com/integr8ly/grafana-operator/v3/pkg/controller/model"
 	v13 "github.com/openshift/api/route/v1"
@@ -13,7 +15,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"os"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"

--- a/pkg/controller/grafana/grafana_controller.go
+++ b/pkg/controller/grafana/grafana_controller.go
@@ -102,7 +102,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler, autodetectChannel chan sch
 					log.Error(err, fmt.Sprintf("error adding secondary watch for %v", common.RouteKind))
 				} else {
 					cfg.AddConfigItem(config.ConfigRouteWatch, true)
-					log.V(1).Info("added secondary watch for %v", common.RouteKind)
+					log.V(1).Info(fmt.Sprintf("added secondary watch for %v", common.RouteKind))
 				}
 			}
 		}

--- a/pkg/controller/grafana/grafana_reconciler.go
+++ b/pkg/controller/grafana/grafana_reconciler.go
@@ -333,12 +333,12 @@ func (i *GrafanaReconciler) reconcilePlugins(cr *v1alpha1.Grafana, plugins v1alp
 
 	for _, plugin := range plugins {
 		if i.Plugins.PluginExists(plugin) == false {
-			log.V(1).Info("invalid plugin: %s@%s", plugin.Name, plugin.Version)
+			log.V(1).Info(fmt.Sprintf("invalid plugin: %s@%s", plugin.Name, plugin.Version))
 			failedPlugins = append(failedPlugins, plugin)
 			continue
 		}
 
-		log.V(1).Info("installing plugin: %s@%s", plugin.Name, plugin.Version)
+		log.V(1).Info(fmt.Sprintf("installing plugin: %s@%s", plugin.Name, plugin.Version))
 		validPlugins = append(validPlugins, plugin)
 	}
 

--- a/pkg/controller/grafanadashboard/dashboard_controller.go
+++ b/pkg/controller/grafanadashboard/dashboard_controller.go
@@ -22,7 +22,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/source"
-	"time"
 )
 
 const (
@@ -242,7 +241,7 @@ func (r *ReconcileGrafanaDashboard) reconcileDashboards(request reconcile.Reques
 		folder, err := grafanaClient.CreateOrUpdateFolder(folderName)
 
 		if err != nil {
-			log.Error(err, "failed to get or create namespace folder %v for dashboard %v with error %v", folderName, request.Name)
+			log.Error(err, fmt.Sprintf("failed to get or create namespace folder %v for dashboard %v", folderName, request.Name))
 			r.manageError(&dashboard, err)
 			continue
 		}
@@ -287,7 +286,7 @@ func (r *ReconcileGrafanaDashboard) reconcileDashboards(request reconcile.Reques
 
 		_, err = grafanaClient.CreateOrUpdateDashboard(processed, folderId, folderName)
 		if err != nil {
-			log.Error(err, "cannot submit dashboard %v/%v", dashboard.Namespace, dashboard.Name)
+			log.Error(err, fmt.Sprintf("cannot submit dashboard %v/%v", dashboard.Namespace, dashboard.Name))
 			r.manageError(&dashboard, err)
 
 			continue

--- a/pkg/controller/grafanadashboard/dashboard_controller.go
+++ b/pkg/controller/grafanadashboard/dashboard_controller.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	defaultErrors "errors"
 	"fmt"
+	"os"
+	"time"
+
 	grafanav1alpha1 "github.com/integr8ly/grafana-operator/v3/pkg/apis/integreatly/v1alpha1"
 	"github.com/integr8ly/grafana-operator/v3/pkg/controller/common"
 	"github.com/integr8ly/grafana-operator/v3/pkg/controller/config"
@@ -14,7 +17,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
-	"os"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"


### PR DESCRIPTION
## Description
The "verbs"(like `%s` and `%v`) in some log messages are not replaced correctly because of the lack of `fmt.Sprintf`.

Like this:
```
{"level":"error","ts":1606811391.4938138,"logger":"controller_grafanadashboard","msg":"failed to get or create namespace folder %v for dashboard %v with error %v","monitoring":"","error":"Get http://admin:***@<IP_ADDR>:3000/api/folders: dial tcp <IP_ADDR>:3000: connect: connection refused","stacktrace":"<STACK_TRACE>"}
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer
