### PR TITLE
Calculate hash value with datasources

### DIFF
--- a/pkg/apis/integreatly/v1alpha1/grafanadashboard_types.go
+++ b/pkg/apis/integreatly/v1alpha1/grafanadashboard_types.go
@@ -6,9 +6,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"strings"
 )
 
 const GrafanaDashboardKind = "GrafanaDashboard"
@@ -76,13 +76,13 @@ func init() {
 }
 
 func (d *GrafanaDashboard) Hash() string {
-	var datasources strings.Builder
+	hash := sha256.New()
+
 	for _, input := range d.Spec.Datasources {
-		datasources.WriteString(input.DatasourceName)
-		datasources.WriteString(input.InputName)
+		io.WriteString(hash, input.DatasourceName)
+		io.WriteString(hash, input.InputName)
 	}
 
-	hash := sha256.New()
 	io.WriteString(hash, d.Spec.Json)
 	io.WriteString(hash, d.Spec.Url)
 	io.WriteString(hash, d.Spec.Jsonnet)


### PR DESCRIPTION
## Description


When I changed the `.spec.datasources` field in GrafanaDashboard CR, grafana-operator did not update the dashboard.
The hash method of GrafanaDashboard may wrong. Could you review this?


## Relevant issues/tickets
<!-- Please include a link to the issue or ticket that applies to this pull request, delete this heading if not relevant -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
<!-- Tick options that apply, in-code tests are not required but please provide test cases and list steps in "verification steps" with the steps you used to verify this -->
- [ ] This change requires a documentation update 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer

## Verification steps
<!-- Please include a series of steps to verify that the functionality/bug fix works, ideally the steps you used to test these changes(if applicable, if not, delete this section)-->
