### PR TITLE
Fix readinessProbeSpec indentation of Grafana CRD

### DIFF
--- a/deploy/crds/Grafana.yaml
+++ b/deploy/crds/Grafana.yaml
@@ -180,36 +180,36 @@ spec:
               Defaults to 3. Minimum value is 1.'
               format: int32
               type: integer
-          readinessProbeSpec:
-            type: object
-            properties:
-              initialDelaySeconds:
-                description: 'Number of seconds after the container has
-                                                 started before liveness probes are initiated. More info:
-                                                 https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                format: int32
-                type: integer
-              timeoutSeconds:
-                description: 'Number of seconds after which the probe times out. Defaults to 1 second.
-                  Minimum value is 1.'
-                format: int32
-                type: integer
-              periodSeconds:
-                description: 'How often (in seconds) to perform the probe.
-                  Default to 10 seconds. Minimum value is 1.'
-                format: int32
-                type: integer
-              successThreshold:
-                description: 'Minimum consecutive successes for the probe
-                  to be considered successful after having failed. Defaults
-                  to 1. Must be 1 for liveness and startup. Minimum value
-                  is 1.'
-                format: int32
-                type: integer
-              failureThreshold:
-                description: 'When a probe fails, Kubernetes will try failureThreshold times before giving up.
-                Giving up in case of liveness probe means restarting the container.
-                In case of readiness probe the Pod will be marked Unready.
-                Defaults to 3. Minimum value is 1.'
-                format: int32
-                type: integer
+        readinessProbeSpec:
+          type: object
+          properties:
+            initialDelaySeconds:
+              description: 'Number of seconds after the container has
+                                               started before liveness probes are initiated. More info:
+                                               https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+              format: int32
+              type: integer
+            timeoutSeconds:
+              description: 'Number of seconds after which the probe times out. Defaults to 1 second.
+                Minimum value is 1.'
+              format: int32
+              type: integer
+            periodSeconds:
+              description: 'How often (in seconds) to perform the probe.
+                Default to 10 seconds. Minimum value is 1.'
+              format: int32
+              type: integer
+            successThreshold:
+              description: 'Minimum consecutive successes for the probe
+                to be considered successful after having failed. Defaults
+                to 1. Must be 1 for liveness and startup. Minimum value
+                is 1.'
+              format: int32
+              type: integer
+            failureThreshold:
+              description: 'When a probe fails, Kubernetes will try failureThreshold times before giving up.
+              Giving up in case of liveness probe means restarting the container.
+              In case of readiness probe the Pod will be marked Unready.
+              Defaults to 3. Minimum value is 1.'
+              format: int32
+              type: integer


### PR DESCRIPTION
Signed-off-by: H.Muraoka <hiroshi-muraoka@cybozu.co.jp>


## Description

Grafana CRD got broken on releasing v3.7.0.
This PR fixes the indentation of readinessProbeSpec to where it should be.

## Relevant issues/tickets
Nothing

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
<!-- Tick options that apply, in-code tests are not required but please provide test cases and list steps in "verification steps" with the steps you used to verify this -->
- [ ] This change requires a documentation update 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer

## Verification steps

I confirmed that the updated CRD is successfully applied on kind.

```
$ cat << EOF > cluster.yaml
kind: Cluster
  # When update to Kubernetes 1.15, make sure to change the
  # apiVersion to "kubeadm.k8s.io/v1beta2".  Also make sure
  # to change the node image in Makefile (--image kindest/node)
apiVersion: kind.sigs.k8s.io/v1alpha3
kubeadmConfigPatches:
- |
  apiVersion: kubeadm.k8s.io/v1beta1
  kind: ClusterConfiguration
  metadata:
    name: config
  kubernetesVersion: "v1.18.8"
  apiServer:
    extraArgs:
      v: 7
  networking:
    serviceSubnet: 10.0.0.0/16
nodes:
- role: control-plane
- role: worker
EOF
$ kind create cluster --config ./cluster.yaml --image kindest/node:v1.18.8
$ kubectl apply -f deploy/crds
```