### PR TITLE
Add missing InfluxDB datasource jsonData fields

### DIFF
--- a/pkg/apis/integreatly/v1alpha1/grafanadatasource_types.go
+++ b/pkg/apis/integreatly/v1alpha1/grafanadatasource_types.go
@@ -131,6 +131,11 @@ type GrafanaDataSourceJsonData struct {
 	LogAnalyticsTenantId         string `json:"logAnalyticsTenantId,omitempty"`
 	SubscriptionId               string `json:"subscriptionI,omitempty"`
 	TenantId                     string `json:"tenantId,omitempty"`
+	// Fields for InfluxDB data sources
+	HTTPMode      string `json:"httpMode,omitempty"`
+	Version       string `json:"version,omitempty"`
+	Organization  string `json:"organization,omitempty"`
+	DefaultBucket string `json:"defaultBucket,omitempty"`
 }
 
 // The most common secure json options
@@ -160,6 +165,8 @@ type GrafanaDataSourceSecureJsonData struct {
 	ClientSecret             string `json:"clientSecret,omitempty"`
 	AppInsightsApiKey        string `json:"appInsightsApiKey,omitempty"`
 	LogAnalyticsClientSecret string `json:"logAnalyticsClientSecret,omitempty"`
+	// Fields for InfluxDB data sources
+	Token string `json:"token,omitempty"`
 }
 
 func init() {


### PR DESCRIPTION
## Description
This change adds support for `jsonData` and `secureJsonData` fields in the `GrafanaDatasource` resource that are used by InfluxDB.

`jsonData`-
- `defaultBucket`
- `httpMode`
- `version`
- `organization`

`secureJsonData` -
- `token`

## Relevant issues/tickets
Resolves https://github.com/integr8ly/grafana-operator/issues/322

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
<!-- Tick options that apply, in-code tests are not required but please provide test cases and list steps in "verification steps" with the steps you used to verify this -->
- [ ] This change requires a documentation update 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer

## Verification steps
Deploy a GrafanaDatasource for an InfluxDB instance using any of the new fields. These should be pulled across to Grafana and the datasource should function.
