### PR TITLE
change base image to ubi-minimal and use 8.3

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi:8.0
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3
 
 RUN mkdir -p /opt/jsonnet && chown nobody /opt/jsonnet
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of the changes, Please add any additional motivation and context as needed -->
This PR is trying to address vulnerabilities with the current image
- use `ubi-minimal` instead of prior `ubi` (half of the things that come with ubi aren't used by us anyway)
- use the latest tagged release: `8.3` 

***openshift-release config will most likely have to be updated as well to ensure CI builds run correctly***

## Relevant issues/tickets
<!-- Please include a link to the issue or ticket that applies to this pull request, delete this heading if not relevant -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
<!-- Tick options that apply, in-code tests are not required but please provide test cases and list steps in "verification steps" with the steps you used to verify this -->
- [ ] This change requires a documentation update 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer

## Verification steps
<!-- Please include a series of steps to verify that the functionality/bug fix works, ideally the steps you used to test these changes(if applicable, if not, delete this section)-->
- run `make image/build` 
- the image should build properly