### PR TITLE
Mgdapi 1030

### DIFF
--- a/pkg/controller/grafana/grafana_controller.go
+++ b/pkg/controller/grafana/grafana_controller.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	stdErr "errors"
 	"fmt"
-
 	grafanav1alpha1 "github.com/integr8ly/grafana-operator/v3/pkg/apis/integreatly/v1alpha1"
 	"github.com/integr8ly/grafana-operator/v3/pkg/controller/common"
 	"github.com/integr8ly/grafana-operator/v3/pkg/controller/config"
@@ -17,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/record"
+	"reflect"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -160,7 +160,7 @@ func (r *ReconcileGrafana) Reconcile(request reconcile.Request) (reconcile.Resul
 	err = currentState.Read(r.context, cr, r.client)
 	if err != nil {
 		log.Error(err, "error reading state")
-		return r.manageError(cr, err)
+		return r.manageError(cr, err, request)
 	}
 
 	// Get the actions required to reach the desired state
@@ -171,30 +171,38 @@ func (r *ReconcileGrafana) Reconcile(request reconcile.Request) (reconcile.Resul
 	actionRunner := common.NewClusterActionRunner(r.context, r.client, r.scheme, cr)
 	err = actionRunner.RunAll(desiredState)
 	if err != nil {
-		return r.manageError(cr, err)
+		return r.manageError(cr, err, request)
 	}
 
 	// Run the config map reconciler to discover jsonnet libraries
 	err = reconcileConfigMaps(cr, r)
 	if err != nil {
-		return r.manageError(cr, err)
+		return r.manageError(cr, err, request)
 	}
 
-	return r.manageSuccess(cr, currentState)
+	return r.manageSuccess(cr, currentState, request)
 }
 
-func (r *ReconcileGrafana) manageError(cr *grafanav1alpha1.Grafana, issue error) (reconcile.Result, error) {
+func (r *ReconcileGrafana) manageError(cr *grafanav1alpha1.Grafana, issue error, request reconcile.Request) (reconcile.Result, error) {
 	r.recorder.Event(cr, "Warning", "ProcessingError", issue.Error())
 	cr.Status.Phase = grafanav1alpha1.PhaseFailing
 	cr.Status.Message = issue.Error()
 
-	err := r.client.Status().Update(r.context, cr)
+	instance := &grafanav1alpha1.Grafana{}
+	err := r.client.Get(r.context, request.NamespacedName, instance)
 	if err != nil {
-		// Ignore conflicts, resource might just be outdated.
-		if errors.IsConflict(err) {
-			err = nil
-		}
 		return reconcile.Result{}, err
+	}
+
+	if !reflect.DeepEqual(cr.Status, instance.Status) {
+		err := r.client.Status().Update(r.context, cr)
+		if err != nil {
+			// Ignore conflicts, resource might just be outdated.
+			if errors.IsConflict(err) {
+				err = nil
+			}
+			return reconcile.Result{}, err
+		}
 	}
 
 	r.config.InvalidateDashboards()
@@ -251,7 +259,7 @@ func (r *ReconcileGrafana) getGrafanaAdminUrl(cr *grafanav1alpha1.Grafana, state
 	return "", stdErr.New("failed to find admin url")
 }
 
-func (r *ReconcileGrafana) manageSuccess(cr *grafanav1alpha1.Grafana, state *common.ClusterState) (reconcile.Result, error) {
+func (r *ReconcileGrafana) manageSuccess(cr *grafanav1alpha1.Grafana, state *common.ClusterState, request reconcile.Request) (reconcile.Result, error) {
 	cr.Status.Phase = grafanav1alpha1.PhaseReconciling
 	cr.Status.Message = "success"
 
@@ -265,15 +273,22 @@ func (r *ReconcileGrafana) manageSuccess(cr *grafanav1alpha1.Grafana, state *com
 		}
 	}
 
-	err := r.client.Status().Update(r.context, cr)
+	instance := &grafanav1alpha1.Grafana{}
+	err := r.client.Get(r.context, request.NamespacedName, instance)
 	if err != nil {
-		return r.manageError(cr, err)
+		return r.manageError(cr, err, request)
 	}
 
+	if !reflect.DeepEqual(cr.Status, instance.Status) {
+		err := r.client.Status().Update(r.context, cr)
+		if err != nil {
+			return r.manageError(cr, err, request)
+		}
+	}
 	// Make the Grafana API URL available to the dashboard controller
 	url, err := r.getGrafanaAdminUrl(cr, state)
 	if err != nil {
-		return r.manageError(cr, err)
+		return r.manageError(cr, err, request)
 	}
 
 	// Publish controller state

--- a/pkg/controller/grafana/grafana_controller.go
+++ b/pkg/controller/grafana/grafana_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	stdErr "errors"
 	"fmt"
+
 	grafanav1alpha1 "github.com/integr8ly/grafana-operator/v3/pkg/apis/integreatly/v1alpha1"
 	"github.com/integr8ly/grafana-operator/v3/pkg/controller/common"
 	"github.com/integr8ly/grafana-operator/v3/pkg/controller/config"
@@ -16,7 +17,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/record"
-	"reflect"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -160,7 +160,7 @@ func (r *ReconcileGrafana) Reconcile(request reconcile.Request) (reconcile.Resul
 	err = currentState.Read(r.context, cr, r.client)
 	if err != nil {
 		log.Error(err, "error reading state")
-		return r.manageError(cr, err, request)
+		return r.manageError(cr, err)
 	}
 
 	// Get the actions required to reach the desired state
@@ -171,38 +171,30 @@ func (r *ReconcileGrafana) Reconcile(request reconcile.Request) (reconcile.Resul
 	actionRunner := common.NewClusterActionRunner(r.context, r.client, r.scheme, cr)
 	err = actionRunner.RunAll(desiredState)
 	if err != nil {
-		return r.manageError(cr, err, request)
+		return r.manageError(cr, err)
 	}
 
 	// Run the config map reconciler to discover jsonnet libraries
 	err = reconcileConfigMaps(cr, r)
 	if err != nil {
-		return r.manageError(cr, err, request)
+		return r.manageError(cr, err)
 	}
 
-	return r.manageSuccess(cr, currentState, request)
+	return r.manageSuccess(cr, currentState)
 }
 
-func (r *ReconcileGrafana) manageError(cr *grafanav1alpha1.Grafana, issue error, request reconcile.Request) (reconcile.Result, error) {
+func (r *ReconcileGrafana) manageError(cr *grafanav1alpha1.Grafana, issue error) (reconcile.Result, error) {
 	r.recorder.Event(cr, "Warning", "ProcessingError", issue.Error())
 	cr.Status.Phase = grafanav1alpha1.PhaseFailing
 	cr.Status.Message = issue.Error()
 
-	instance := &grafanav1alpha1.Grafana{}
-	err := r.client.Get(r.context, request.NamespacedName, instance)
+	err := r.client.Status().Update(r.context, cr)
 	if err != nil {
-		return reconcile.Result{}, err
-	}
-
-	if !reflect.DeepEqual(cr.Status, instance.Status) {
-		err := r.client.Status().Update(r.context, cr)
-		if err != nil {
-			// Ignore conflicts, resource might just be outdated.
-			if errors.IsConflict(err) {
-				err = nil
-			}
-			return reconcile.Result{}, err
+		// Ignore conflicts, resource might just be outdated.
+		if errors.IsConflict(err) {
+			err = nil
 		}
+		return reconcile.Result{}, err
 	}
 
 	r.config.InvalidateDashboards()
@@ -259,7 +251,7 @@ func (r *ReconcileGrafana) getGrafanaAdminUrl(cr *grafanav1alpha1.Grafana, state
 	return "", stdErr.New("failed to find admin url")
 }
 
-func (r *ReconcileGrafana) manageSuccess(cr *grafanav1alpha1.Grafana, state *common.ClusterState, request reconcile.Request) (reconcile.Result, error) {
+func (r *ReconcileGrafana) manageSuccess(cr *grafanav1alpha1.Grafana, state *common.ClusterState) (reconcile.Result, error) {
 	cr.Status.Phase = grafanav1alpha1.PhaseReconciling
 	cr.Status.Message = "success"
 
@@ -273,22 +265,15 @@ func (r *ReconcileGrafana) manageSuccess(cr *grafanav1alpha1.Grafana, state *com
 		}
 	}
 
-	instance := &grafanav1alpha1.Grafana{}
-	err := r.client.Get(r.context, request.NamespacedName, instance)
+	err := r.client.Status().Update(r.context, cr)
 	if err != nil {
-		return r.manageError(cr, err, request)
+		return r.manageError(cr, err)
 	}
 
-	if !reflect.DeepEqual(cr.Status, instance.Status) {
-		err := r.client.Status().Update(r.context, cr)
-		if err != nil {
-			return r.manageError(cr, err, request)
-		}
-	}
 	// Make the Grafana API URL available to the dashboard controller
 	url, err := r.getGrafanaAdminUrl(cr, state)
 	if err != nil {
-		return r.manageError(cr, err, request)
+		return r.manageError(cr, err)
 	}
 
 	// Publish controller state


### PR DESCRIPTION
## Description
Grafana cr is constantly update causing errors where the resource is out of date. These updates are updating the CR with the same information in the status block and are uneeded. This pr only updates when the status block is different. 

## Relevant issues/tickets
https://issues.redhat.com/browse/MGDAPI-1030
## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist
<!-- Tick options that apply, in-code tests are not required but please provide test cases and list steps in "verification steps" with the steps you used to verify this -->
- [ ] This change requires a documentation update 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer

## Verification steps
install current 3.7.0 version and verify that the CR is constantly updated. In Openshift, view the CR yaml and click the reload button each time its update and verify the increase in version revision. 

Install from this branch and verify CR is only updated as status changes happen rather than on every reconciliation 
