### PR TITLE
INTLY-10372: Safely read and write plugins concurrently

### DIFF
--- a/pkg/controller/config/controller_config.go
+++ b/pkg/controller/config/controller_config.go
@@ -61,6 +61,17 @@ func (c *ControllerConfig) GetDashboardId(namespace, name string) string {
 	return fmt.Sprintf("%v/%v", namespace, name)
 }
 
+func (c *ControllerConfig) GetAllPlugins() v1alpha1.PluginList {
+	c.Lock()
+	defer c.Unlock()
+
+	var plugins v1alpha1.PluginList
+	for _, v := range GetControllerConfig().Plugins {
+		plugins = append(plugins, v...)
+	}
+	return plugins
+}
+
 func (c *ControllerConfig) GetPluginsFor(dashboard *v1alpha1.GrafanaDashboard) v1alpha1.PluginList {
 	c.Lock()
 	defer c.Unlock()

--- a/pkg/controller/config/controller_config_test.go
+++ b/pkg/controller/config/controller_config_test.go
@@ -1,0 +1,44 @@
+package config
+
+import (
+	"github.com/integr8ly/grafana-operator/v3/pkg/apis/integreatly/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+	"time"
+)
+
+func TestControllerConfig_ConcurrentlyReadAndWritePlugins(t *testing.T) {
+
+	go func() {
+		// Continuously read all Plugins
+		for {
+			_ = GetControllerConfig().GetAllPlugins()
+		}
+	}()
+
+	go func() {
+		// Continuously overwrite existing Plugins
+		for {
+			c := GetControllerConfig()
+
+			d := &v1alpha1.GrafanaDashboard{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "crash",
+				},
+				Spec: v1alpha1.GrafanaDashboardSpec{
+					Plugins: []v1alpha1.GrafanaPlugin{
+						{Name: "one", Version: "0"},
+						{Name: "two", Version: "0"},
+						{Name: "tttt", Version: "0"},
+						{Name: "four", Version: "0"},
+					},
+				},
+			}
+			c.SetPluginsFor(d)
+		}
+	}()
+
+	// it will take less then a second to panic if read and write happen at the same time
+	time.Sleep(time.Second)
+}

--- a/pkg/controller/grafana/grafana_reconciler.go
+++ b/pkg/controller/grafana/grafana_reconciler.go
@@ -296,10 +296,7 @@ func (i *GrafanaReconciler) getEnvVarsDesiredState(state *common.ClusterState, c
 
 func (i *GrafanaReconciler) getGrafanaPluginsDesiredState(cr *v1alpha1.Grafana) common.ClusterAction {
 	// Fetch all plugins of all dashboards
-	var requestedPlugins v1alpha1.PluginList
-	for _, v := range config.GetControllerConfig().Plugins {
-		requestedPlugins = append(requestedPlugins, v...)
-	}
+	requestedPlugins := config.GetControllerConfig().GetAllPlugins()
 
 	// Consolidate plugins and create the new list of plugin requirements
 	// If 'updated' is false then no changes have to be applied


### PR DESCRIPTION
## Description

The grafana-operator can periodically crash with this error:
```
fatal error: concurrent map iteration and map write

goroutine 1964 [running]:
runtime.throw(0x169597f, 0x26)
	/home/travis/.gimme/versions/go1.13.15.linux.amd64/src/runtime/panic.go:774 +0x72 fp=0xc0000217d8 sp=0xc0000217a8 pc=0x42e642
runtime.mapiternext(0xc0000218f0)
	/home/travis/.gimme/versions/go1.13.15.linux.amd64/src/runtime/map.go:858 +0x579 fp=0xc000021860 sp=0xc0000217d8 pc=0x40f259
github.com/integr8ly/grafana-operator/v3/pkg/controller/grafana.(*GrafanaReconciler).getGrafanaPluginsDesiredState(0xc000021b68, 0xc000287c00, 0x4, 0x4)
	grafana-operator/pkg/controller/grafana/grafana_reconciler.go:300 +0xe9 fp=0xc000021960 sp=0xc000021860 pc=0x12b9e99
github.com/integr8ly/grafana-operator/v3/pkg/controller/grafana.(*GrafanaReconciler).Reconcile(0xc000021b68, 0xc000021be0, 0xc000287c00, 0xc000287c00, 0x18db980, 0xc0006559e0)
	grafana-operator/pkg/controller/grafana/grafana_reconciler.go:45 +0x496 fp=0xc000021a78 sp=0xc000021960 pc=0x12b7526
github.com/integr8ly/grafana-operator/v3/pkg/controller/grafana.(*ReconcileGrafana).Reconcile(0xc000235a40, 0xc000221d70, 0x2a, 0xc000cad218, 0x7, 0xc000021ca0, 0xc0005d78c0, 0xc0003522d8, 0x1899940)
	grafana-operator/pkg/controller/grafana/grafana_controller.go:168 +0x2cd fp=0xc000021c38 sp=0xc000021a78 pc=0x12b5cbd
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc0001da540, 0x1509320, 0xc000419a20, 0xc000299d00)
	/home/travis/gopath/pkg/mod/sigs.k8s.io/controller-runtime@v0.6.0/pkg/internal/controller/controller.go:256 +0x162 fp=0xc000021d78 sp=0xc000021c38 pc=0x12afc92
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc0001da540, 0x40a900)
	/home/travis/gopath/pkg/mod/sigs.k8s.io/controller-runtime@v0.6.0/pkg/internal/controller/controller.go:232 +0xcb fp=0xc000021e00 sp=0xc000021d78 pc=0x12afadb
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker(0xc0001da540)
	/home/travis/gopath/pkg/mod/sigs.k8s.io/controller-runtime@v0.6.0/pkg/internal/controller/controller.go:211 +0x2b fp=0xc000021e20 sp=0xc000021e00 pc=0x12af9eb
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker-fm()
	/home/travis/gopath/pkg/mod/sigs.k8s.io/controller-runtime@v0.6.0/pkg/internal/controller/controller.go:210 +0x2a fp=0xc000021e38 sp=0xc000021e20 pc=0x12b146a
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0xc0006dae80)
	/home/travis/gopath/pkg/mod/k8s.io/apimachinery@v0.18.2/pkg/util/wait/wait.go:155 +0x5e fp=0xc000021ea8 sp=0xc000021e38 pc=0x10ee4ee
k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xc0006dae80, 0x1889fe0, 0xc000321e60, 0xc00000e801, 0xc00033af00)
	/home/travis/gopath/pkg/mod/k8s.io/apimachinery@v0.18.2/pkg/util/wait/wait.go:156 +0xa3 fp=0xc000021f48 sp=0xc000021ea8 pc=0x10ed5e3
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc0006dae80, 0x3b9aca00, 0x0, 0xc000403a01, 0xc00033af00)
	/home/travis/gopath/pkg/mod/k8s.io/apimachinery@v0.18.2/pkg/util/wait/wait.go:133 +0xe2 fp=0xc000021f90 sp=0xc000021f48 pc=0x10ed512
k8s.io/apimachinery/pkg/util/wait.Until(0xc0006dae80, 0x3b9aca00, 0xc00033af00)
	/home/travis/gopath/pkg/mod/k8s.io/apimachinery@v0.18.2/pkg/util/wait/wait.go:90 +0x4d fp=0xc000021fc8 sp=0xc000021f90 pc=0x10ed41d
runtime.goexit()
	/home/travis/.gimme/versions/go1.13.15.linux.amd64/src/runtime/asm_amd64.s:1357 +0x1 fp=0xc000021fd0 sp=0xc000021fc8 pc=0x45b761
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1
	/home/travis/gopath/pkg/mod/sigs.k8s.io/controller-runtime@v0.6.0/pkg/internal/controller/controller.go:193 +0x328
```

this PR should fix the issue by locking the `ControllerConfig` when reading the plugins.

## Relevant issues/tickets
https://issues.redhat.com/browse/INTLY-10372

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
<!-- Tick options that apply, in-code tests are not required but please provide test cases and list steps in "verification steps" with the steps you used to verify this -->
- [ ] This change requires a documentation update 
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer

## Verification steps
1. Remove `c.Lock()` and `defer c.Unlock()` on line 65 and 66 in pkg/controller/config/controller_config.go
2. Run the `TestControllerConfig_ConcurrentlyReadAndWritePlugins` test
