### PR TITLE
Add permissions to create events

### DIFF
--- a/deploy/cluster_roles/cluster_role_grafana_operator.yaml
+++ b/deploy/cluster_roles/cluster_role_grafana_operator.yaml
@@ -14,4 +14,8 @@ rules:
     resources:
       - namespaces
     verbs: ['get', 'list', 'watch']
-
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs: ['create']

--- a/deploy/cluster_roles/cluster_role_grafana_operator.yaml
+++ b/deploy/cluster_roles/cluster_role_grafana_operator.yaml
@@ -18,4 +18,4 @@ rules:
       - ""
     resources:
       - events
-    verbs: ['create']
+    verbs: ['create', 'patch']


### PR DESCRIPTION
Added missing permission to create events in case operator is being set up to manage dashboards in multiple namespaces.

Without these permissions the following error happens:
`User "system:serviceaccount:epic-system:grafana-operator" cannot create resource "events" in API group "" in the namespace "default"' (will not retry!)`