### PR TITLE
Added support for Datasource OauthPassThru (Forward OAuth Identity)

### DIFF
--- a/pkg/apis/integreatly/v1alpha1/grafanadatasource_types.go
+++ b/pkg/apis/integreatly/v1alpha1/grafanadatasource_types.go
@@ -2,8 +2,9 @@ package v1alpha1
 
 import (
 	"fmt"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const GrafanaDataSourceKind = "GrafanaDataSource"
@@ -73,6 +74,7 @@ type GrafanaDataSourceFields struct {
 // The most common json options
 // See https://grafana.com/docs/administration/provisioning/#datasources
 type GrafanaDataSourceJsonData struct {
+	OauthPassThru           bool   `json:"oauthPassThru,omitempty"`
 	TlsAuth                 bool   `json:"tlsAuth,omitempty"`
 	TlsAuthWithCACert       bool   `json:"tlsAuthWithCACert,omitempty"`
 	TlsSkipVerify           bool   `json:"tlsSkipVerify,omitempty"`


### PR DESCRIPTION
## Description
Grafana has an option to forward user's upstream OAuth identity to a data source. Basically, it means that a user's jwt token gets passed along in the Authorization header with every request sent to a data source. - It's incredible useful in environments where token claims influence authorization decisions (like whether a user should have access to certain metrics or endpoints).

The option is called "Forward OAuth Identity" ([oauthPassThru](https://github.com/grafana/grafana/blob/1d689888b0fc2de2dbed6e606eee19561a3ef006/packages/grafana-ui/src/components/DataSourceSettings/HttpProxySettings.tsx#L38)):
![image](https://user-images.githubusercontent.com/46579601/106795585-5051bd00-666b-11eb-8a8a-d36f8d7a5b4b.png)
The proposed change adds support for that.

## Type of change
- [X] New feature (non-breaking change which adds functionality)

## Checklist
- [ ] This change requires a documentation update 
I've added an example below, you might want to include it in the documentation. Though, I'm not sure if we should document every possible option :) So, it's up to you to decide.
- [X] I have added a test case that will be used to verify my changes 
- [X] Verified independently on a cluster by reviewer

## Verification steps
1. Deploy a data source with the following specification:

```yaml
apiVersion: integreatly.org/v1alpha1
kind: GrafanaDataSource
metadata:
  name: example-grafanadatasource
spec:
  name: middleware.yaml
  datasources:
    - name: Prometheus
      type: prometheus
      access: proxy
      url: http://prometheus-service:9090
      isDefault: true
      version: 1
      editable: true
      jsonData:
        tlsSkipVerify: true
        oauthPassThru: true
```

2. Go to the data source settings (Configuration -> Datasources -> Prometheus) and find the section "Auth". The `Forward OAuth Identity` option should be turned on.