### PR TITLE
Remove unusued spec.name

### DIFF
--- a/deploy/examples/dashboards/DashboardFromConfigMap.yaml
+++ b/deploy/examples/dashboards/DashboardFromConfigMap.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     app: grafana
 spec:
-  name: grafana-dashboard-from-config-map.json
   configMapRef:
     name: simple-dashboard-from-cm
     key: foo

--- a/deploy/examples/dashboards/DashboardFromURL.yaml
+++ b/deploy/examples/dashboards/DashboardFromURL.yaml
@@ -5,6 +5,5 @@ metadata:
   labels: 
     app: grafana
 spec: 
-  name: grafana-dashboard-from-url.json
   url: https://raw.githubusercontent.com/integr8ly/grafana-operator/master/deploy/examples/remote/grafana-dashboard.json
   json:

--- a/deploy/examples/dashboards/DashboardWithCustomFolder.yaml
+++ b/deploy/examples/dashboards/DashboardWithCustomFolder.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     app: grafana
 spec:
-  name: dashboard-with-custom-folder.json
   customFolderName: "newCustomFolder"
   json: >
     {

--- a/deploy/examples/dashboards/DashboardWithPlugins.yaml
+++ b/deploy/examples/dashboards/DashboardWithPlugins.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     app: grafana
 spec:
-  name: dashboard-with-plugins.json
   json: >
     {
       "id": null,

--- a/deploy/examples/dashboards/KeycloakDashboard.yaml
+++ b/deploy/examples/dashboards/KeycloakDashboard.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     app: grafana
 spec:
-  name: keycloak-dashboard.json
   plugins:
     - name: grafana-piechart-panel
       version: 1.3.9

--- a/deploy/examples/dashboards/SimpleDashboard.yaml
+++ b/deploy/examples/dashboards/SimpleDashboard.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     app: grafana
 spec:
-  name: simple-dashboard.json
   json: >
     {
       "id": null,

--- a/documentation/dashboards.md
+++ b/documentation/dashboards.md
@@ -10,7 +10,6 @@ Dashboards are represented by the `GrafanaDashboard` custom resource. Examples c
 
 The following properties are accepted in the `spec`:
 
-* *name*: The filename of the dashboard that gets mounted into a volume in the grafana instance. Not to be confused with `metadata.name`.
 * *json*: Raw json string with the dashboard contents. Check the [official documentation](https://grafana.com/docs/reference/dashboard/#dashboard-json).
 * *jsonnet*: Jsonnet source. The [Grafonnet](https://grafana.github.io/grafonnet-lib/) library is made available automatically and can be imported.
 * *url*: Url address to download a json or jsonnet string with the dashboard contents. 

--- a/pkg/apis/integreatly/v1alpha1/grafanadashboard_types.go
+++ b/pkg/apis/integreatly/v1alpha1/grafanadashboard_types.go
@@ -22,7 +22,6 @@ type GrafanaDashboardSpec struct {
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
 	Json             string                       `json:"json"`
 	Jsonnet          string                       `json:"jsonnet"`
-	Name             string                       `json:"name"`
 	Plugins          PluginList                   `json:"plugins,omitempty"`
 	Url              string                       `json:"url,omitempty"`
 	ConfigMapRef     *corev1.ConfigMapKeySelector `json:"configMapRef,omitempty"`


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>


## Description
This PR removes spec.name from doc, dashboards examples and schema

## Relevant issues/tickets
Fixes: https://github.com/integr8ly/grafana-operator/issues/339

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] This change requires a documentation update 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer

## Verification steps
