### PR TITLE
Added support for login_maximum_lifetime_duration, login_maximum_inac…

### DIFF
--- a/pkg/apis/integreatly/v1alpha1/grafana_types.go
+++ b/pkg/apis/integreatly/v1alpha1/grafana_types.go
@@ -231,14 +231,16 @@ type GrafanaConfigUsers struct {
 }
 
 type GrafanaConfigAuth struct {
-	LoginCookieName                  string `json:"login_cookie_name,omitempty" ini:"login_cookie_name,omitempty"`
-	LoginMaximumInactiveLifetimeDays *int   `json:"login_maximum_inactive_lifetime_days,omitempty" ini:"login_maximum_inactive_lifetime_days,omitempty"`
-	LoginMaximumLifetimeDays         *int   `json:"login_maximum_lifetime_days,omitempty" ini:"login_maximum_lifetime_days,omitempty"`
-	TokenRotationIntervalMinutes     *int   `json:"token_rotation_interval_minutes,omitempty" ini:"token_rotation_interval_minutes,omitempty"`
-	DisableLoginForm                 *bool  `json:"disable_login_form,omitempty" ini:"disable_login_form"`
-	DisableSignoutMenu               *bool  `json:"disable_signout_menu,omitempty" ini:"disable_signout_menu"`
-	SignoutRedirectUrl               string `json:"signout_redirect_url,omitempty" ini:"signout_redirect_url,omitempty"`
-	OauthAutoLogin                   *bool  `json:"oauth_auto_login,omitempty" ini:"oauth_auto_login"`
+	LoginCookieName                      string `json:"login_cookie_name,omitempty" ini:"login_cookie_name,omitempty"`
+	LoginMaximumInactiveLifetimeDays     *int   `json:"login_maximum_inactive_lifetime_days,omitempty" ini:"login_maximum_inactive_lifetime_days,omitempty"`
+	LoginMaximumInactiveLifetimeDuration string `json:"login_maximum_inactive_lifetime_duration,omitempty" ini:"login_maximum_inactive_lifetime_duration,omitempty"`
+	LoginMaximumLifetimeDays             *int   `json:"login_maximum_lifetime_days,omitempty" ini:"login_maximum_lifetime_days,omitempty"`
+	LoginMaximumLifetimeDuration         string `json:"login_maximum_lifetime_duration,omitempty" ini:"login_maximum_lifetime_duration,omitempty"`
+	TokenRotationIntervalMinutes         *int   `json:"token_rotation_interval_minutes,omitempty" ini:"token_rotation_interval_minutes,omitempty"`
+	DisableLoginForm                     *bool  `json:"disable_login_form,omitempty" ini:"disable_login_form"`
+	DisableSignoutMenu                   *bool  `json:"disable_signout_menu,omitempty" ini:"disable_signout_menu"`
+	SignoutRedirectUrl                   string `json:"signout_redirect_url,omitempty" ini:"signout_redirect_url,omitempty"`
+	OauthAutoLogin                       *bool  `json:"oauth_auto_login,omitempty" ini:"oauth_auto_login"`
 }
 
 type GrafanaConfigAuthBasic struct {

--- a/pkg/controller/config/grafanaIni.go
+++ b/pkg/controller/config/grafanaIni.go
@@ -156,7 +156,9 @@ func (i *GrafanaIni) Write() (string, string) {
 		var items []string
 		items = appendStr(items, "login_cookie_name", i.cfg.Auth.LoginCookieName)
 		items = appendInt(items, "login_maximum_inactive_lifetime_days", i.cfg.Auth.LoginMaximumInactiveLifetimeDays)
+		items = appendStr(items, "login_maximum_inactive_lifetime_duration", i.cfg.Auth.LoginMaximumInactiveLifetimeDuration)
 		items = appendInt(items, "login_maximum_lifetime_days", i.cfg.Auth.LoginMaximumLifetimeDays)
+		items = appendStr(items, "login_maximum_lifetime_duration", i.cfg.Auth.LoginMaximumLifetimeDuration)
 		items = appendInt(items, "token_rotation_interval_minutes", i.cfg.Auth.TokenRotationIntervalMinutes)
 		items = appendBool(items, "disable_login_form", i.cfg.Auth.DisableLoginForm)
 		items = appendBool(items, "disable_signout_menu", i.cfg.Auth.DisableSignoutMenu)


### PR DESCRIPTION
## Description
In Grafana [v7.2.0-beta2](https://github.com/grafana/grafana/releases/tag/v7.2.0-beta2), PR [#27150](https://github.com/grafana/grafana/pull/27150) made transition from `login_maximum_inactive_lifetime_days` and `login_maximum_lifetime_days` to `login_maximum_inactive_lifetime_duration` and `login_maximum_lifetime_duration`, which allowed to specify any duration, including hours and minutes. A fresh configuration example can be found over [here](https://github.com/grafana/grafana/blob/c2203b985929c0273afe132b0df7a06859b41b24/conf/defaults.ini#L321).

The suggested changes will make the operator compatible with the new options. //(upd: added this line to clarify the intention of the PR)
I have not deleted the old options as they still remain supported in Grafana's recent releases.

## Type of change
- [X] New feature (non-breaking change which adds functionality)

## Checklist
- [ ] This change requires a documentation update 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have added a test case that will be used to verify my changes 
- [X] Verified independently on a cluster by reviewer

## Verification steps
Deploy Grafana with the above-mentioned options in spec:
```yaml
  spec:
    config:
      auth:
        login_maximum_inactive_lifetime_duration: 4h
        login_maximum_lifetime_duration: 8h
```
The operator should generate a ConfigMap with the options included:
![image](https://user-images.githubusercontent.com/46579601/107260589-52db5a80-6a4f-11eb-90fd-207f7f16aa25.png)