### PR TITLE
Adding support for overriding Grafana plugins init image

### DIFF
--- a/documentation/deploy_grafana.md
+++ b/documentation/deploy_grafana.md
@@ -156,6 +156,10 @@ The resource accepts the following properties in it's `spec`:
     - ***Warning!*** this overwrites the `--grafana-image` Operator flag, please refer to the grafana image support
       chart.
 
+* ***initImage***: Specifies a custom grafana plugins init image for this deployment.
+    - ***Warning!*** this overwrites the `--grafana-plugins-init-container-image` Operator flag, please refer to the grafana image support
+      chart.
+
 * ***dashboardLabelSelector***: A list of either `matchLabels` or `matchExpressions` to filter the dashboards before
   importing them.
 

--- a/pkg/apis/integreatly/v1alpha1/grafana_types.go
+++ b/pkg/apis/integreatly/v1alpha1/grafana_types.go
@@ -34,6 +34,7 @@ type GrafanaSpec struct {
 	DataStorage                *GrafanaDataStorage      `json:"dataStorage,omitempty"`
 	Jsonnet                    *JsonnetConfig           `json:"jsonnet,omitempty"`
 	BaseImage                  string                   `json:"baseImage,omitempty"`
+	InitImage                  string                   `json:"initImage,omitempty"`
 	LivenessProbeSpec          *LivenessProbeSpec       `json:"livenessProbeSpec,omitempty"`
 	ReadinessProbeSpec         *ReadinessProbeSpec      `json:"readinessProbeSpec,omitempty"`
 }

--- a/pkg/controller/model/grafanaDeployment.go
+++ b/pkg/controller/model/grafanaDeployment.go
@@ -496,8 +496,14 @@ func getContainers(cr *v1alpha1.Grafana, configHash, dsHash string) []v13.Contai
 
 func getInitContainers(cr *v1alpha1.Grafana, plugins string) []v13.Container {
 	cfg := config.GetControllerConfig()
-	image := cfg.GetConfigString(config.ConfigPluginsInitContainerImage, config.PluginsInitContainerImage)
-	tag := cfg.GetConfigString(config.ConfigPluginsInitContainerTag, config.PluginsInitContainerTag)
+	var image string
+
+	if cr.Spec.InitImage != "" {
+		image = cr.Spec.InitImage
+	} else {
+		image := cfg.GetConfigString(config.ConfigPluginsInitContainerImage, config.PluginsInitContainerImage)
+		tag := cfg.GetConfigString(config.ConfigPluginsInitContainerTag, config.PluginsInitContainerTag)
+	}
 
 	return []v13.Container{
 		{

--- a/pkg/controller/model/grafanaDeployment.go
+++ b/pkg/controller/model/grafanaDeployment.go
@@ -508,7 +508,6 @@ func getInitContainers(cr *v1alpha1.Grafana, plugins string) []v13.Container {
 		image = fmt.Sprintf("%s:%s", repo, tag)
 	}
 
-
 	return []v13.Container{
 		{
 			Name:  GrafanaInitContainerName,

--- a/pkg/controller/model/grafanaDeployment.go
+++ b/pkg/controller/model/grafanaDeployment.go
@@ -496,7 +496,15 @@ func getContainers(cr *v1alpha1.Grafana, configHash, dsHash string) []v13.Contai
 
 func getInitContainers(cr *v1alpha1.Grafana, plugins string) []v13.Container {
 	cfg := config.GetControllerConfig()
-	var image string
+     var image string
+     var tag string
+
+	if cr.Spec.InitImage != "" {
+		image = cr.Spec.InitImage
+	} else {
+		image = cfg.GetConfigString(config.ConfigPluginsInitContainerImage, config.PluginsInitContainerImage)
+		tag = cfg.GetConfigString(config.ConfigPluginsInitContainerTag, config.PluginsInitContainerTag)
+	}
 
 	if cr.Spec.InitImage != "" {
 		image = cr.Spec.InitImage

--- a/pkg/controller/model/grafanaDeployment.go
+++ b/pkg/controller/model/grafanaDeployment.go
@@ -496,21 +496,23 @@ func getContainers(cr *v1alpha1.Grafana, configHash, dsHash string) []v13.Contai
 
 func getInitContainers(cr *v1alpha1.Grafana, plugins string) []v13.Container {
 	cfg := config.GetControllerConfig()
-     var image string
-     var tag string
+	var image string
+	var tag string
+	var repo string
 
 	if cr.Spec.InitImage != "" {
 		image = cr.Spec.InitImage
 	} else {
-		image = cfg.GetConfigString(config.ConfigPluginsInitContainerImage, config.PluginsInitContainerImage)
+		repo = cfg.GetConfigString(config.ConfigPluginsInitContainerImage, config.PluginsInitContainerImage)
 		tag = cfg.GetConfigString(config.ConfigPluginsInitContainerTag, config.PluginsInitContainerTag)
+		image = fmt.Sprintf("%s:%s", repo, tag)
 	}
 
 
 	return []v13.Container{
 		{
 			Name:  GrafanaInitContainerName,
-			Image: fmt.Sprintf("%s:%s", image, tag),
+			Image: image,
 			Env: []v13.EnvVar{
 				{
 					Name:  "GRAFANA_PLUGINS",

--- a/pkg/controller/model/grafanaDeployment.go
+++ b/pkg/controller/model/grafanaDeployment.go
@@ -506,12 +506,6 @@ func getInitContainers(cr *v1alpha1.Grafana, plugins string) []v13.Container {
 		tag = cfg.GetConfigString(config.ConfigPluginsInitContainerTag, config.PluginsInitContainerTag)
 	}
 
-	if cr.Spec.InitImage != "" {
-		image = cr.Spec.InitImage
-	} else {
-		image := cfg.GetConfigString(config.ConfigPluginsInitContainerImage, config.PluginsInitContainerImage)
-		tag := cfg.GetConfigString(config.ConfigPluginsInitContainerTag, config.PluginsInitContainerTag)
-	}
 
 	return []v13.Container{
 		{


### PR DESCRIPTION
## Description
<!-- Please include a summary of the changes, Please add any additional motivation and context as needed -->

Deploying a Grafana instance in a restricted network requires one to override the default Grafana image (`grafana/grafana`) as well as the default Grafana Plugins Init Container image (`quay.io/integreatly/grafana_plugins_init`).

Within the Grafana custom resource, there is currently support for passing `baseImage` into its `spec`.  This Pull Request will provide support for passing `initImage` into its `spec` as well, so that both can be supplied within the CR exclusively and not via the operator deployment's `args` section.  This will make it easier for users in a restricted network to configure custom images.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
<!-- Tick options that apply, in-code tests are not required but please provide test cases and list steps in "verification steps" with the steps you used to verify this -->
- [ ] This change requires a documentation update 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer

## Verification steps
<!-- Please include a series of steps to verify that the functionality/bug fix works, ideally the steps you used to test these changes(if applicable, if not, delete this section)-->
1. Deploy new operator

2. Deploy Grafana CR with `spec.initImage` supplied:
```
apiVersion: integreatly.org/v1alpha1
kind: Grafana
metadata:
  name: example-grafana
  namespace: my-grafana
spec:
  baseImage: registry.example.com/grafana/grafana:7.1.1
  initImage: registry.example.com/integreatly/grafana_plugins_init:0.0.3
  config:
    auth:
      disable_signout_menu: true
    auth.anonymous:
      enabled: true
    log:
      level: warn
      mode: console
    security:
      admin_password: secret
      admin_user: root
  ingress:
    enabled: true
  dashboardLabelSelector:
    - matchExpressions:
        - key: app
          operator: In
          values:
            - grafana
```