### PR TITLE
Add support for Datasource Custom query parameters (customQueryParame…

### DIFF
--- a/pkg/apis/integreatly/v1alpha1/grafanadatasource_types.go
+++ b/pkg/apis/integreatly/v1alpha1/grafanadatasource_types.go
@@ -142,6 +142,8 @@ type GrafanaDataSourceJsonData struct {
 	// Fields for Loki data sources
 	MaxLines      int                                  `json:"maxLines,omitempty"`
 	DerivedFields []GrafanaDataSourceJsonDerivedFields `json:"derivedFields,omitempty"`
+	// Fields for Prometheus data sources
+	customQueryParameters string `json:"customQueryParameters,omitempty"`
 }
 
 type GrafanaDataSourceJsonDerivedFields struct {

--- a/pkg/apis/integreatly/v1alpha1/grafanadatasource_types.go
+++ b/pkg/apis/integreatly/v1alpha1/grafanadatasource_types.go
@@ -143,7 +143,7 @@ type GrafanaDataSourceJsonData struct {
 	MaxLines      int                                  `json:"maxLines,omitempty"`
 	DerivedFields []GrafanaDataSourceJsonDerivedFields `json:"derivedFields,omitempty"`
 	// Fields for Prometheus data sources
-	customQueryParameters string `json:"customQueryParameters,omitempty"`
+	CustomQueryParameters string `json:"customQueryParameters,omitempty"`
 }
 
 type GrafanaDataSourceJsonDerivedFields struct {


### PR DESCRIPTION
## Description
Grafana has an option to define **Custom query parameters** on an Prometheus data source. 
Basically, it means that this query parameter add to the Promtheus or Thanos queries.

The query parameter example is required if OpenShift's user-defined monitoring is used as Prometheus datasource.
The OpenShift thanos-querier (https://thanos-querier.openshift-monitoring.svc.cluster.local:9092) needed the URL parameter "namespace=yournamespace" in the query as parameter.

The option on the Prometheus datasource is called "Custom query parameters" (customQueryParameters) in the section "Misc":
![image](https://user-images.githubusercontent.com/44832499/107821444-bed5ff80-6d7c-11eb-82bb-3b521c0c2227.png)

The proposed change adds support for set the Custom query parameters via the GrafanaDatasource CRD.

## Relevant issues/tickets
PR https://github.com/integr8ly/grafana-operator/issues/309

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [ ] This change requires a documentation update 
       I've added an example below, you might want to include it in the documentation. But not all option are documented 

- [x] I have added a test case that will be used to verify my changes 
- [x] Verified independently on a cluster by reviewer

## Verification steps
1. Deploy a data source (GrafanaDatasource) with the following specification:
```yaml
apiVersion: integreatly.org/v1alpha1
kind: GrafanaDataSource
metadata:
  name: test-grafanadatasource
spec:
  name: prometheus.yaml
  datasources:
    - name: Prometheus
      type: prometheus
      access: proxy
      url: https://thanos-querier.openshift-monitoring.svc.cluster.local:9092
      isDefault: true
      version: 1
      editable: true
      jsonData:
        tlsSkipVerify: true
        customQueryParameters: "namespace=ns1"
```
2. In Grafana go to the data source settings (Configuration -> Datasources -> Prometheus)
    The Custom query parameters option should be set to "namespace=ns1".
![image](https://user-images.githubusercontent.com/44832499/107823306-d95da800-6d7f-11eb-90b7-351bc07d0ed1.png)
