### PR TITLE
Add sigv4 authentication

### DIFF
--- a/pkg/apis/integreatly/v1alpha1/grafana_types.go
+++ b/pkg/apis/integreatly/v1alpha1/grafana_types.go
@@ -241,6 +241,7 @@ type GrafanaConfigAuth struct {
 	TokenRotationIntervalMinutes         *int   `json:"token_rotation_interval_minutes,omitempty" ini:"token_rotation_interval_minutes,omitempty"`
 	DisableLoginForm                     *bool  `json:"disable_login_form,omitempty" ini:"disable_login_form"`
 	DisableSignoutMenu                   *bool  `json:"disable_signout_menu,omitempty" ini:"disable_signout_menu"`
+	SigV4AuthEnabled                     *bool  `json:"sigv4_auth_enabled,omitempty" ini:"sigv4_auth_enabled"`
 	SignoutRedirectUrl                   string `json:"signout_redirect_url,omitempty" ini:"signout_redirect_url,omitempty"`
 	OauthAutoLogin                       *bool  `json:"oauth_auto_login,omitempty" ini:"oauth_auto_login"`
 }

--- a/pkg/apis/integreatly/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/integreatly/v1alpha1/zz_generated.deepcopy.go
@@ -345,6 +345,11 @@ func (in *GrafanaConfigAuth) DeepCopyInto(out *GrafanaConfigAuth) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.SigV4AuthEnabled != nil {
+		in, out := &in.SigV4AuthEnabled, &out.SigV4AuthEnabled
+		*out = new(bool)
+		**out = **in
+	}
 	if in.OauthAutoLogin != nil {
 		in, out := &in.OauthAutoLogin, &out.OauthAutoLogin
 		*out = new(bool)

--- a/pkg/controller/config/grafanaIni.go
+++ b/pkg/controller/config/grafanaIni.go
@@ -162,6 +162,7 @@ func (i *GrafanaIni) Write() (string, string) {
 		items = appendInt(items, "token_rotation_interval_minutes", i.cfg.Auth.TokenRotationIntervalMinutes)
 		items = appendBool(items, "disable_login_form", i.cfg.Auth.DisableLoginForm)
 		items = appendBool(items, "disable_signout_menu", i.cfg.Auth.DisableSignoutMenu)
+		items = appendBool(items, "sigv4_auth_enabled", i.cfg.Auth.SigV4AuthEnabled)
 		items = appendStr(items, "signout_redirect_url", i.cfg.Auth.SignoutRedirectUrl)
 		items = appendBool(items, "oauth_auto_login", i.cfg.Auth.OauthAutoLogin)
 		config["auth"] = items

--- a/pkg/controller/model/constants.go
+++ b/pkg/controller/model/constants.go
@@ -2,7 +2,7 @@ package model
 
 const (
 	GrafanaImage                        = "grafana/grafana"
-	GrafanaVersion                      = "7.1.1"
+	GrafanaVersion                      = "7.3.1"
 	GrafanaServiceAccountName           = "grafana-serviceaccount"
 	GrafanaServiceName                  = "grafana-service"
 	GrafanaDataStorageName              = "grafana-pvc"


### PR DESCRIPTION
Sigv4 is a prerequisite for connecting to a Prometheus data source that is managed by AWS
https://docs.aws.amazon.com/prometheus/latest/userguide/AMP-onboard-query-standalone-grafana.html

Upgrade to Grafana 7.3.1 is required since sigv4 is introduced there