### PR TITLE
Added support for pathType, ingressClassName

### DIFF
--- a/deploy/crds/Grafana.yaml
+++ b/deploy/crds/Grafana.yaml
@@ -64,9 +64,15 @@ spec:
                 enabled:
                   type: boolean
                   description: Create an ingress / route
+                ingressClassName:
+                  type: string
+                  description: Ingress class name
                 path:
                   type: string
                   description: Ingress path
+                pathType:
+                  type: string
+                  description: pathType specifies how ingress paths should be matched
                 hostname:
                   type: string
                   description: The hostname of the ingress / route

--- a/documentation/deploy_grafana.md
+++ b/documentation/deploy_grafana.md
@@ -227,6 +227,7 @@ configured:
 spec:
   ingress:
     enabled: <Boolean>     # Create an Ingress (or Route if on OpenShift)
+    ingressClassName: <String> # Sets ingress ingressClassName
     hostname: <String>      # Sets the hostname. Assigned automatically on OpenShift if not provided
     tlsEnabled: <Boolean>   # Enable TLS on Ingress
     tlsSecretName: <String> # TLS secret name in the same namespace
@@ -239,6 +240,7 @@ spec:
       app: grafana
       ...
     path:                   # Sets the path of the Ingress. Ignored for Routes
+    pathType: <String>      # Sets pathType: ImplementationSpecific, Exact, Prefix (defaults to ImplementationSpecific)
 ```
 
 ## Configuring the ServiceAccount

--- a/pkg/apis/integreatly/v1alpha1/grafana_types.go
+++ b/pkg/apis/integreatly/v1alpha1/grafana_types.go
@@ -108,15 +108,17 @@ type GrafanaDeployment struct {
 
 // GrafanaIngress provides a means to configure the ingress created
 type GrafanaIngress struct {
-	Annotations   map[string]string      `json:"annotations,omitempty"`
-	Hostname      string                 `json:"hostname,omitempty"`
-	Labels        map[string]string      `json:"labels,omitempty"`
-	Path          string                 `json:"path,omitempty"`
-	Enabled       bool                   `json:"enabled,omitempty"`
-	TLSEnabled    bool                   `json:"tlsEnabled,omitempty"`
-	TLSSecretName string                 `json:"tlsSecretName,omitempty"`
-	TargetPort    string                 `json:"targetPort,omitempty"`
-	Termination   v12.TLSTerminationType `json:"termination,omitempty"`
+	Annotations      map[string]string      `json:"annotations,omitempty"`
+	Hostname         string                 `json:"hostname,omitempty"`
+	Labels           map[string]string      `json:"labels,omitempty"`
+	Path             string                 `json:"path,omitempty"`
+	Enabled          bool                   `json:"enabled,omitempty"`
+	TLSEnabled       bool                   `json:"tlsEnabled,omitempty"`
+	TLSSecretName    string                 `json:"tlsSecretName,omitempty"`
+	TargetPort       string                 `json:"targetPort,omitempty"`
+	Termination      v12.TLSTerminationType `json:"termination,omitempty"`
+	IngressClassName string                 `json:"ingressClassName,omitempty"`
+	PathType         string                 `json:"pathType,omitempty"`
 }
 
 // GrafanaConfig is the configuration for grafana

--- a/pkg/controller/model/grafanaIngress.go
+++ b/pkg/controller/model/grafanaIngress.go
@@ -18,6 +18,10 @@ func GetIngressPathType(cr *v1alpha1.Grafana) *v1beta1.PathType {
 }
 
 func GetIngressClassName(cr *v1alpha1.Grafana) *string {
+	if cr.Spec.Ingress.IngressClassName == "" {
+		return nil
+	}
+
 	return &cr.Spec.Ingress.IngressClassName
 }
 

--- a/pkg/controller/model/grafanaIngress.go
+++ b/pkg/controller/model/grafanaIngress.go
@@ -7,6 +7,20 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+func GetIngressPathType(cr *v1alpha1.Grafana) *v1beta1.PathType {
+	t := v1beta1.PathType(cr.Spec.Ingress.PathType)
+	switch t {
+	case v1beta1.PathTypeExact, v1beta1.PathTypePrefix:
+		return &t
+	}
+	t = v1beta1.PathTypeImplementationSpecific
+	return &t
+}
+
+func GetIngressClassName(cr *v1alpha1.Grafana) *string {
+	return &cr.Spec.Ingress.IngressClassName
+}
+
 func getIngressTLS(cr *v1alpha1.Grafana) []v1beta1.IngressTLS {
 	if cr.Spec.Ingress == nil {
 		return nil
@@ -31,7 +45,8 @@ func getIngressSpec(cr *v1alpha1.Grafana) v1beta1.IngressSpec {
 		return GrafanaServiceName
 	}
 	return v1beta1.IngressSpec{
-		TLS: getIngressTLS(cr),
+		TLS:              getIngressTLS(cr),
+		IngressClassName: GetIngressClassName(cr),
 		Rules: []v1beta1.IngressRule{
 			{
 				Host: GetHost(cr),
@@ -39,7 +54,8 @@ func getIngressSpec(cr *v1alpha1.Grafana) v1beta1.IngressSpec {
 					HTTP: &v1beta1.HTTPIngressRuleValue{
 						Paths: []v1beta1.HTTPIngressPath{
 							{
-								Path: GetPath(cr),
+								Path:     GetPath(cr),
+								PathType: GetIngressPathType(cr),
 								Backend: v1beta1.IngressBackend{
 									ServiceName: serviceName(cr),
 									ServicePort: GetIngressTargetPort(cr),


### PR DESCRIPTION
## Description

Kubernetes 1.18 brought a few [changes](https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/) in API for ingress:
* A new `pathType` field that can specify how Ingress paths should be matched.
* A new `IngressClass` resource that can specify how Ingresses should be implemented by controllers.
* Support for wildcards in hostnames.
This PR covers the first two (I guess, the third one should already work, haven't checked it).

1. `pathType` could be one of the following: `ImplementationSpecific`, `Exact`, `Prefix` (defaults to `ImplementationSpecific`).
  API gives controllers freedom to decide what `ImplementationSpecific` means to them. - They could treat it as a separate `PathType` or identically to `Prefix` or `Exact` path types ([docs](https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#ingress-v1beta1-networking-k8s-io)).
  To give some examples, for nginx `ImplementationSpecific` = `Prefix`, for Istio - `Exact` (meaning, you can't access subpaths in URI, by default). That's why it's important to support this feature in grafana-operator.
  **Note:** Since k8s defines an exact set of `pathType`s and offers a default value, I decided to let operator fall back to `ImplementationSpecific` in case of incorrect input. I can change that if it doesn't fit your view of how opinionated on the inputs the operator should be.
  **Note:** I tried to implement `pathType` using `*v1beta1.PathType`, though it didn't work very well (not at all, tbh :D). I haven't seen any issues with `string` (`*v1beta1.PathType` is actually a string const), so stayed with it.

2. `IngressClass`. In modern Kubernetes environments, the `kubernetes.io/ingress.class` annotation is deprecated in favour of `IngressClass`. I guess it doesn't require any additional comments :)

## Relevant issues/tickets
None

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## Checklist
<!-- Tick options that apply, in-code tests are not required but please provide test cases and list steps in "verification steps" with the steps you used to verify this -->
- [X] This change requires a documentation update **(included in PR)**
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have added a test case that will be used to verify my changes 
- [X] Verified independently on a cluster by reviewer

## Verification steps

Deploy grafana with similar set of settings to the one below:
```yaml
    ingress:
      enabled: true
      hostname: grafana.microk8s.localhost
      ingressClassName: nginx
      path: /
      pathType: Prefix
      tlsEnabled: true
      tlsSecretName: grafana-tls
```

For k8s 1.18+, you should see both `ingressClassName` and `pathType` in the resulting ingress:

```yaml
~ k get ingress grafana-ingress -o yaml
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
[...]
spec:
  ingressClassName: nginx
  rules:
  - host: grafana.microk8s.localhost
    http:
      paths:
      - backend:
          serviceName: grafana-service
          servicePort: 3000
        path: /
        pathType: Prefix
```

For k8s <1.18, both `ingressClassName` and `pathType` will be absent in the resulting ingress (underlying lib handles it well):

```yaml
~ k get ingress grafana-ingress -o yaml
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
[...]
spec:
  rules:
  - host: grafana.microk8s.localhost
    http:
      paths:
      - backend:
          serviceName: grafana-service
          servicePort: 3000
        path: /
```