### PR TITLE
fix: dont rely on service clusterip, prefer dns name

### DIFF
--- a/pkg/controller/grafana/grafana_controller.go
+++ b/pkg/controller/grafana/grafana_controller.go
@@ -249,10 +249,7 @@ func (r *ReconcileGrafana) getGrafanaAdminUrl(cr *grafanav1alpha1.Grafana, state
 	var servicePort = int32(model.GetGrafanaPort(cr))
 
 	// Otherwise rely on the service
-	if state.GrafanaService != nil && state.GrafanaService.Spec.ClusterIP != "" && state.GrafanaService.Spec.ClusterIP != "None" {
-		return fmt.Sprintf("http://%v:%d", state.GrafanaService.Spec.ClusterIP,
-			servicePort), nil
-	} else if state.GrafanaService != nil {
+	if state.GrafanaService != nil {
 		return fmt.Sprintf("http://%v:%d", state.GrafanaService.Name,
 			servicePort), nil
 	}


### PR DESCRIPTION
## Description

Don't rely on the service ClusterIP, always prefer the DNS name.

## Relevant issues/tickets

#337 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Verification steps

1. Deploy the operator from this image: quay.io/pb82/grafana-operator:latest
2. Create a Grafana CR with `preferService` set to `true`.
3. Create some dashboards, make sure they are imported.
4. Delete the dashboards.
5. You should not see any failed API requests in the Operator logs.