### PR TITLE
Add containerSecurityContext init-container #372

### DIFF
--- a/documentation/deploy_grafana.md
+++ b/documentation/deploy_grafana.md
@@ -323,6 +323,7 @@ spec:
 
 NOTE: Some key's are common to both in securityContext and containerSecurityContext, in that case
 containerSecurityContext has precendence over securityContext.
+ContainerSecurityContext defined in deployment will also apply to the init-container.
 
 ## Configuring Grafana API access
 
@@ -351,7 +352,7 @@ spec:
       ...
     accessModes: # An array of access modes, e.g. `ReadWriteOnce`
       ...
-    size: <Quantity>        # Requested size, e.g. `10Gi` 
+    size: <Quantity>        # Requested size, e.g. `10Gi`
     class: <String>         # Storage class name
 ```
 

--- a/pkg/controller/model/grafanaDeployment.go
+++ b/pkg/controller/model/grafanaDeployment.go
@@ -529,6 +529,7 @@ func getInitContainers(cr *v1alpha1.Grafana, plugins string) []v13.Container {
 			TerminationMessagePath:   "/dev/termination-log",
 			TerminationMessagePolicy: "File",
 			ImagePullPolicy:          "IfNotPresent",
+			SecurityContext:          getContainerSecurityContext(cr),
 		},
 	}
 }


### PR DESCRIPTION
## Description
Add containerSeucirtyContext to init-container to be able to start the grafana-operator in a hardly locked down psp environment.

## Relevant issues/tickets
https://github.com/integr8ly/grafana-operator/issues/372

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

This could potentially break custom init-containers where they want to be allowed to use other containerSecurityContext vs what they have in there normal grafana containers. Rather low risk but still possible.

## Checklist
<!-- Tick options that apply, in-code tests are not required but please provide test cases and list steps in "verification steps" with the steps you used to verify this -->
- [x ] This change requires a documentation update 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer

## Verification steps
<!-- Please include a series of steps to verify that the functionality/bug fix works, ideally the steps you used to test these changes(if applicable, if not, delete this section)-->

make code/run

Apply the following yaml:
```yaml
apiVersion: integreatly.org/v1alpha1
kind: Grafana
metadata:
  name: grafana
spec:
  deployment:
    containerSecurityContext:
      allowPrivilegeEscalation: false
      capabilities:
        drop:
          - NET_RAW
      readOnlyRootFilesystem: true
```

When your deployment/rs/pod have been created you will be able to see the following:
```yaml
      initContainers:
      - env:
        - name: GRAFANA_PLUGINS
        image: quay.io/integreatly/grafana_plugins_init:0.0.3
        imagePullPolicy: IfNotPresent
        name: grafana-plugins-init
        resources:
          limits:
            cpu: "1"
            memory: 512Mi
          requests:
            cpu: 250m
            memory: 128Mi
        securityContext:
          allowPrivilegeEscalation: false
          capabilities:
            drop:
            - NET_RAW
          readOnlyRootFilesystem: true
```
