### PR TITLE
Added support for httpMethod

### DIFF
--- a/pkg/apis/integreatly/v1alpha1/grafanadatasource_types.go
+++ b/pkg/apis/integreatly/v1alpha1/grafanadatasource_types.go
@@ -144,6 +144,7 @@ type GrafanaDataSourceJsonData struct {
 	DerivedFields []GrafanaDataSourceJsonDerivedFields `json:"derivedFields,omitempty"`
 	// Fields for Prometheus data sources
 	CustomQueryParameters string `json:"customQueryParameters,omitempty"`
+	HTTPMethod            string `json:"httpMethod,omitempty"`
 }
 
 type GrafanaDataSourceJsonDerivedFields struct {


### PR DESCRIPTION
## Description

The suggested change adds support for [httpMethod](https://grafana.com/docs/grafana/latest/administration/provisioning/#example-datasource-config-file), which lets you specify a preferred HTTP method for a datasource (GET / POST).

Motivation:
* Grafana is moving to use POST by default for new instances ([PR](https://github.com/grafana/grafana/pull/31292)). You might want to keep using GET due to some constraints.
* You might want to actually use POST in older versions of Grafana as it offers a larger query body.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] This change requires a documentation update 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have added a test case that will be used to verify my changes 
- [X] Verified independently on a cluster by reviewer

## Verification steps

1. Include `httpMethod: POST` within `jsonData` block inside `GrafanaDataSource` CR.

```yaml
apiVersion: integreatly.org/v1alpha1
kind: GrafanaDataSource
metadata:
  name: example-grafanadatasource
spec:
  name: middleware.yaml
  datasources:
    - name: Prometheus
      type: prometheus
      access: proxy
      url: http://prometheus-service:9090
      isDefault: true
      version: 1
      editable: true
      jsonData:
        httpMethod: POST
        tlsSkipVerify: true
        timeInterval: "5s"
```

2. Go to Data Sources -> Prometheus -> Settings, look for "HTTP Method", it should be set to "POST".
![image](https://user-images.githubusercontent.com/46579601/112722063-6451c680-8f18-11eb-81da-66c74a362c2e.png)

