### PR TITLE
Add in support for auth.okta to grafana.ini parser.

### DIFF
--- a/pkg/apis/integreatly/v1alpha1/grafana_types.go
+++ b/pkg/apis/integreatly/v1alpha1/grafana_types.go
@@ -137,6 +137,7 @@ type GrafanaConfig struct {
 	AuthGithub                    *GrafanaConfigAuthGithub                    `json:"auth.github,omitempty" ini:"auth.github,omitempty"`
 	AuthGitlab                    *GrafanaConfigAuthGitlab                    `json:"auth.gitlab,omitempty" ini:"auth.gitlab,omitempty"`
 	AuthGenericOauth              *GrafanaConfigAuthGenericOauth              `json:"auth.generic_oauth,omitempty" ini:"auth.generic_oauth,omitempty"`
+	AuthOkta                      *GrafanaConfigAuthOkta                      `json:"auth.okta,omitempty" ini:"auth.okta,omitempty"`
 	AuthLdap                      *GrafanaConfigAuthLdap                      `json:"auth.ldap,omitempty" ini:"auth.ldap,omitempty"`
 	AuthProxy                     *GrafanaConfigAuthProxy                     `json:"auth.proxy,omitempty" ini:"auth.proxy,omitempty"`
 	AuthSaml                      *GrafanaConfigAuthSaml                      `json:"auth.saml,omitempty" ini:"auth.saml,omitempty"`
@@ -346,6 +347,21 @@ type GrafanaConfigAuthGenericOauth struct {
 	TLSClientCert         string `json:"tls_client_cert,omitempty" ini:"tls_client_cert,omitempty"`
 	TLSClientKey          string `json:"tls_client_key,omitempty" ini:"tls_client_key,omitempty"`
 	TLSClientCa           string `json:"tls_client_ca,omitempty" ini:"tls_auth_ca,omitempty"`
+}
+
+type GrafanaConfigAuthOkta struct {
+	Enabled           *bool  `json:"enabled,omitempty" ini:"enabled"`
+	Name              string `json:"name,omitempty" ini:"name,omitempty"`
+	AllowSignUp       *bool  `json:"allow_sign_up,omitempty" ini:"allow_sign_up"`
+	ClientId          string `json:"client_id,omitempty" ini:"client_id,omitempty"`
+	ClientSecret      string `json:"client_secret,omitempty" ini:"client_secret,omitempty"`
+	Scopes            string `json:"scopes,omitempty" ini:"scopes,omitempty"`
+	AuthUrl           string `json:"auth_url,omitempty" ini:"auth_url,omitempty"`
+	TokenUrl          string `json:"token_url,omitempty" ini:"token_url,omitempty"`
+	ApiUrl            string `json:"api_url,omitempty" ini:"api_url,omitempty"`
+	AllowedDomains    string `json:"allowed_domains,omitempty" ini:"allowed_domains,omitempty"`
+	AllowedGroups     string `json:"allowed_groups,omitempty" ini:"allowed_groups,omitempty"`
+	RoleAttributePath string `json:"role_attribute_path,omitempty" ini:"role_attribute_path,omitempty"`
 }
 
 type GrafanaConfigAuthLdap struct {

--- a/pkg/controller/config/grafanaIni.go
+++ b/pkg/controller/config/grafanaIni.go
@@ -283,6 +283,23 @@ func (i *GrafanaIni) Write() (string, string) {
 		config["auth.generic_oauth"] = items
 	}
 
+	if i.cfg.AuthOkta != nil {
+		var items []string
+		items = appendBool(items, "enabled", i.cfg.AuthOkta.Enabled)
+		items = appendStr(items, "name", i.cfg.AuthOkta.Name)
+		items = appendBool(items, "allow_sign_up", i.cfg.AuthOkta.AllowSignUp)
+		items = appendStr(items, "client_id", i.cfg.AuthOkta.ClientId)
+		items = appendStr(items, "client_secret", i.cfg.AuthOkta.ClientSecret)
+		items = appendStr(items, "scopes", i.cfg.AuthOkta.Scopes)
+		items = appendStr(items, "auth_url", i.cfg.AuthOkta.AuthUrl)
+		items = appendStr(items, "token_url", i.cfg.AuthOkta.TokenUrl)
+		items = appendStr(items, "api_url", i.cfg.AuthOkta.ApiUrl)
+		items = appendStr(items, "allowed_domains", i.cfg.AuthOkta.AllowedDomains)
+		items = appendStr(items, "allowed_groups", i.cfg.AuthOkta.AllowedGroups)
+		items = appendStr(items, "role_attribute_path", i.cfg.AuthOkta.RoleAttributePath)
+		config["auth.okta"] = items
+	}
+
 	if i.cfg.AuthLdap != nil {
 		var items []string
 		items = appendBool(items, "enabled", i.cfg.AuthLdap.Enabled)


### PR DESCRIPTION
## Description
Enables support fot the auth.okta section of the grafana.ini parser.

## Relevant issues/tickets
https://github.com/integr8ly/grafana-operator/issues/378

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
<!-- Tick options that apply, in-code tests are not required but please provide test cases and list steps in "verification steps" with the steps you used to verify this -->
- [ ] This change requires a documentation update 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer

## Verification steps
Use a CRD with with the auth.okta enabled and validate it is rendered in the grafana.ini configmap.
```
apiVersion: integreatly.org/v1alpha1
kind: Grafana
metadata:
  name: grafana
  namespace: grafana
spec:
  deployment:
    nodeSelector:
      nodegroup: kube-addons
  ingress:
    enabled: true
    ingressClassName: nginx-private
    hostname: grafana.foo.net
    path: /
    annotations:
      kubernetes.io/ingress.class: nginx-private
      cert-manager.io/cluster-issuer: vault
      external-dns/private-record: 'true'
    tlsEnabled: true
    tlsSecretName: grafana-tls
    termination: edge
  config:
    alerting:
      enabled: false
    analytics:
      check_for_updates: false
      reporting_enabled: false
    auth.okta:
      enabled: true
      allow_sign_up: true
      client_id: $__file{/etc/grafana-secrets/auth_okta/client_id}
      client_secret: $__file{/etc/grafana-secrets/auth_okta/client_secret}
      scopes: openid profile email groups
      auth_url: https://foo.com/oauth2/v1/authorize
      token_url: https://foo.com/oauth2/v1/token
      api_url: https://foo.com/oauth2/v1/userinfo
      allowed_domains: foo.com
      allowed_groups: k8s-eng-svcs k8s-eng-svcs-admins
      role_attribute_path: contains(groups[*], 'k8s-eng-svcs-admins') && 'Admin' ||
        contains(groups[*], 'k8s-eng-svcs-admins') && 'Editor' || 'Viewer'
    log:
      level: warn
      mode: console
    security:
      disable_gravatar: true
    server:
      root_url: https://grafana.foo.net
  secrets:
  - auth-okta-secret
```