### PR TITLE
Set GrafanaPlugin name & version to requiered

### DIFF
--- a/api/integreatly/v1alpha1/grafana_types.go
+++ b/api/integreatly/v1alpha1/grafana_types.go
@@ -506,8 +506,11 @@ type GrafanaStatus struct {
 }
 
 // GrafanaPlugin contains information about a single plugin
+// +k8s:openapi-gen=true
 type GrafanaPlugin struct {
-	Name    string `json:"name"`
+	// +kubebuilder:validation:Required
+	Name string `json:"name"`
+	// +kubebuilder:validation:Required
 	Version string `json:"version"`
 }
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of the changes, Please add any additional motivation and context as needed -->
This should solve #388.
Making sure that both Name and Version is defined in GrafanaPlugin
the error rate among users should become lower.

## Relevant issues/tickets
<!-- Please include a link to the issue or ticket that applies to this pull request, delete this heading if not relevant -->
https://github.com/integr8ly/grafana-operator/issues/388

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
<!-- Tick options that apply, in-code tests are not required but please provide test cases and list steps in "verification steps" with the steps you used to verify this -->
- [ ] This change requires a documentation update 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer

## Verification steps
<!-- Please include a series of steps to verify that the functionality/bug fix works, ideally the steps you used to test these changes(if applicable, if not, delete this section)-->

Sadly I can't verify this since we are  currently using operator-sdk v.0.18.2.
I have tested to do similar things on operator-sdk v1.3.2 and I can see that the CRD definition get's updated.
These changes won't create any effect until the upgrade to v1.3.2  is done: https://github.com/integr8ly/grafana-operator/pull/327.
