### PR TITLE
.Fix typo subscriptionId

### DIFF
--- a/pkg/apis/integreatly/v1alpha1/grafanadatasource_types.go
+++ b/pkg/apis/integreatly/v1alpha1/grafanadatasource_types.go
@@ -132,7 +132,7 @@ type GrafanaDataSourceJsonData struct {
 	LogAnalyticsClientId         string `json:"logAnalyticsClientId,omitempty"`
 	LogAnalyticsSubscriptionId   string `json:"logAnalyticsSubscriptionId,omitempty"`
 	LogAnalyticsTenantId         string `json:"logAnalyticsTenantId,omitempty"`
-	SubscriptionId               string `json:"subscriptionI,omitempty"`
+	SubscriptionId               string `json:"subscriptionId,omitempty"`
 	TenantId                     string `json:"tenantId,omitempty"`
 	// Fields for InfluxDB data sources
 	HTTPMode      string `json:"httpMode,omitempty"`


### PR DESCRIPTION
## Description
There is a typo for the Azure datasource field subscriptionId which prevents the operator of parsing the datasource correctly

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Verification steps
- use operator with existing Azure datasource example: https://github.com/integr8ly/grafana-operator/blob/master/deploy/examples/datasources/Azure.yaml
- subscriptionId should be parsed correctly now
