### PR TITLE
Use fully qualified image name

### DIFF
--- a/documentation/deploy_grafana.md
+++ b/documentation/deploy_grafana.md
@@ -117,7 +117,7 @@ work as expected.
 
 The operator accepts a number of flags that can be passed in the `args` section of the container in the deployment:
 
-* `--grafana-image`: overrides the Grafana image, defaults to `grafana/grafana` on grafanas official dockerhub, the
+* `--grafana-image`: overrides the Grafana image, defaults to `docker.io/grafana/grafana` on grafanas official dockerhub, the
   version of which can be
   found [here](https://github.com/integr8ly/grafana-operator/blob/master/pkg/controller/model/constants.go#L4-L5).
 

--- a/pkg/controller/model/constants.go
+++ b/pkg/controller/model/constants.go
@@ -1,7 +1,7 @@
 package model
 
 const (
-	GrafanaImage                        = "grafana/grafana"
+	GrafanaImage                        = "docker.io/grafana/grafana"
 	GrafanaVersion                      = "7.3.10"
 	GrafanaServiceAccountName           = "grafana-serviceaccount"
 	GrafanaServiceName                  = "grafana-service"


### PR DESCRIPTION
## Description
In OpenShift, if you use a pull secret for Docker Hub, it will only be used if the fully qualified image name is used. The common reason for a pull secret is to deal with the Docker Hub rate limit.

Otherwise I have to overwrite with `baseimage` to work around the rate limit.

## Relevant issues/tickets
https://developers.redhat.com/blog/2021/02/18/how-to-work-around-dockers-new-download-rate-limit-on-red-hat-openshift/

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [X] This change requires a documentation update 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer

## Verification steps

Pod is deployed with the FQIN in its spec.