### PR TITLE
bump to version 3.10.1 to pick up CVE fix on base image

### DIFF
--- a/deploy/olm-catalog/grafana-operator/3.x.x/3.10.1/grafana-operator.v3.10.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/grafana-operator/3.x.x/3.10.1/grafana-operator.v3.10.1.clusterserviceversion.yaml
@@ -1,0 +1,221 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: "[\n{\n  \"apiVersion\": \"integreatly.org/v1alpha1\",\n  \"kind\"\
+      : \"Grafana\",\n  \"metadata\": {\n    \"name\": \"example-grafana\"\n  },\n\
+      \  \"spec\": {\n    \"ingress\": {\n      \"enabled\": true\n    },\n    \"\
+      config\": {\n      \"auth\": {\n        \"disable_signout_menu\": true\n   \
+      \   },\n      \"auth.anonymous\": {\n        \"enabled\": true\n      },\n \
+      \     \"log\": {\n        \"level\": \"warn\",\n        \"mode\": \"console\"\
+      \n      },\n      \"security\": {\n        \"admin_password\": \"secret\",\n\
+      \        \"admin_user\": \"root\"\n      }\n    },\n    \"dashboardLabelSelector\"\
+      : [\n    {\n      \"matchExpressions\": [\n      {\n        \"key\": \"app\"\
+      ,\n        \"operator\": \"In\",\n        \"values\": [\n          \"grafana\"\
+      \n        ]\n      }\n      ]\n    }\n    ]\n  }\n},\n{\n  \"apiVersion\": \"\
+      integreatly.org/v1alpha1\",\n  \"kind\": \"GrafanaDashboard\",\n  \"metadata\"\
+      : {\n    \"labels\": {\n      \"app\": \"grafana\"\n    },\n    \"name\": \"\
+      simple-dashboard\"\n  },\n  \"spec\": {\n    \"json\": \"{\\n  \\\"id\\\": null,\\\
+      n  \\\"title\\\": \\\"Simple Dashboard\\\",\\n  \\\"tags\\\": [],\\n  \\\"style\\\
+      \": \\\"dark\\\",\\n  \\\"timezone\\\": \\\"browser\\\",\\n  \\\"editable\\\"\
+      : true,\\n  \\\"hideControls\\\": false,\\n  \\\"graphTooltip\\\": 1,\\n  \\\
+      \"panels\\\": [],\\n  \\\"time\\\": {\\n    \\\"from\\\": \\\"now-6h\\\",\\\
+      n    \\\"to\\\": \\\"now\\\"\\n  },\\n  \\\"timepicker\\\": {\\n    \\\"time_options\\\
+      \": [],\\n    \\\"refresh_intervals\\\": []\\n  },\\n  \\\"templating\\\": {\\\
+      n    \\\"list\\\": []\\n  },\\n  \\\"annotations\\\": {\\n    \\\"list\\\":\
+      \ []\\n  },\\n  \\\"refresh\\\": \\\"5s\\\",\\n  \\\"schemaVersion\\\": 17,\\\
+      n  \\\"version\\\": 0,\\n  \\\"links\\\": []\\n}\\n\",\n    \"name\": \"simple-dashboard.json\"\
+      \n  }\n},\n{\n  \"apiVersion\": \"integreatly.org/v1alpha1\",\n  \"kind\": \"\
+      GrafanaDataSource\",\n  \"metadata\": {\n    \"name\": \"example-grafanadatasource\"\
+      \n  },\n  \"spec\": {\n    \"datasources\": [\n    {\n      \"access\": \"proxy\"\
+      ,\n      \"editable\": true,\n      \"isDefault\": true,\n      \"jsonData\"\
+      : {\n        \"timeInterval\": \"5s\"\n      },\n      \"name\": \"Prometheus\"\
+      ,\n      \"type\": \"prometheus\",\n      \"url\": \"http://prometheus-service:9090\"\
+      ,\n      \"version\": 1\n    }\n    ],\n    \"name\": \"example-datasources.yaml\"\
+      \n  }\n}\n]"
+    capabilities: Basic Install
+    categories: Monitoring
+    certified: 'False'
+    containerImage: quay.io/integreatly/grafana-operator:v3.10.1
+    createdAt: 2020-07-31 00:00:00
+    description: An Operator for managing Grafana instances, dashboards and data sources
+    repository: https://github.com/integr8ly/grafana-operator
+    support: Red Hat
+  name: grafana-operator.v3.10.1
+  namespace: placeholder
+spec:
+  apiservicedefinitions: { }
+  customresourcedefinitions:
+    owned:
+      - description: Represents a Grafana Instance
+        displayName: Grafana
+        kind: Grafana
+        name: grafanas.integreatly.org
+        version: v1alpha1
+      - description: Represents a Grafana Dashboard
+        displayName: Grafana Dashboard
+        kind: GrafanaDashboard
+        name: grafanadashboards.integreatly.org
+        version: v1alpha1
+      - description: Represents a Grafana Data Source
+        displayName: Grafana Data Source
+        kind: GrafanaDataSource
+        name: grafanadatasources.integreatly.org
+        version: v1alpha1
+  description: 'A Kubernetes Operator based on the Operator SDK for creating and managing
+    Grafana instances.
+
+
+    Grafana is an open platform for beautiful analytics and monitoring. For more information
+    please visit the [Grafana website](https://grafana.com)
+
+
+    # Current status
+
+
+    The Operator can deploy and manage a Grafana instance on Kubernetes and OpenShift.
+    The following features are supported:
+
+
+    * Install Grafana to a namespace
+
+    * Configure Grafana through the custom resource
+
+    * Import Grafana dashboards from the same or other namespaces
+
+    * Import Grafana data sources from the same namespace
+
+    * Install Plugins (panels)
+
+    '
+  displayName: Grafana Operator
+  icon:
+    - base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+CjwhLS0gR2VuZXJhdG9yOiBBZG9iZSBJbGx1c3RyYXRvciAyMC4xLjAsIFNWRyBFeHBvcnQgUGx1Zy1JbiAuIFNWRyBWZXJzaW9uOiA2LjAwIEJ1aWxkIDApICAtLT4KCjxzdmcKICAgeG1sbnM6ZGM9Imh0dHA6Ly9wdXJsLm9yZy9kYy9lbGVtZW50cy8xLjEvIgogICB4bWxuczpjYz0iaHR0cDovL2NyZWF0aXZlY29tbW9ucy5vcmcvbnMjIgogICB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiCiAgIHhtbG5zOnN2Zz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciCiAgIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICAgeG1sbnM6c29kaXBvZGk9Imh0dHA6Ly9zb2RpcG9kaS5zb3VyY2Vmb3JnZS5uZXQvRFREL3NvZGlwb2RpLTAuZHRkIgogICB4bWxuczppbmtzY2FwZT0iaHR0cDovL3d3dy5pbmtzY2FwZS5vcmcvbmFtZXNwYWNlcy9pbmtzY2FwZSIKICAgdmVyc2lvbj0iMS4xIgogICBpZD0iTGF5ZXJfMSIKICAgeD0iMHB4IgogICB5PSIwcHgiCiAgIHdpZHRoPSI1Ny43OTk5OTkiCiAgIGhlaWdodD0iNTcuNzk5OTk5IgogICB2aWV3Qm94PSIwIDAgNTcuNzk5OTk5IDU3LjgiCiAgIHhtbDpzcGFjZT0icHJlc2VydmUiCiAgIHNvZGlwb2RpOmRvY25hbWU9ImxvZ29fc21hbGwuc3ZnIgogICBpbmtzY2FwZTp2ZXJzaW9uPSIwLjkyLjQgKDVkYTY4OWMzMTMsIDIwMTktMDEtMTQpIj48bWV0YWRhdGEKICAgaWQ9Im1ldGFkYXRhMzc4NSI+PHJkZjpSREY+PGNjOldvcmsKICAgICAgIHJkZjphYm91dD0iIj48ZGM6Zm9ybWF0PmltYWdlL3N2Zyt4bWw8L2RjOmZvcm1hdD48ZGM6dHlwZQogICAgICAgICByZGY6cmVzb3VyY2U9Imh0dHA6Ly9wdXJsLm9yZy9kYy9kY21pdHlwZS9TdGlsbEltYWdlIiAvPjxkYzp0aXRsZT48L2RjOnRpdGxlPjwvY2M6V29yaz48L3JkZjpSREY+PC9tZXRhZGF0YT48ZGVmcwogICBpZD0iZGVmczM3ODMiIC8+PHNvZGlwb2RpOm5hbWVkdmlldwogICBwYWdlY29sb3I9IiNmZmZmZmYiCiAgIGJvcmRlcmNvbG9yPSIjNjY2NjY2IgogICBib3JkZXJvcGFjaXR5PSIxIgogICBvYmplY3R0b2xlcmFuY2U9IjEwIgogICBncmlkdG9sZXJhbmNlPSIxMCIKICAgZ3VpZGV0b2xlcmFuY2U9IjEwIgogICBpbmtzY2FwZTpwYWdlb3BhY2l0eT0iMCIKICAgaW5rc2NhcGU6cGFnZXNoYWRvdz0iMiIKICAgaW5rc2NhcGU6d2luZG93LXdpZHRoPSIyNTYwIgogICBpbmtzY2FwZTp3aW5kb3ctaGVpZ2h0PSIxMzg2IgogICBpZD0ibmFtZWR2aWV3Mzc4MSIKICAgc2hvd2dyaWQ9ImZhbHNlIgogICBpbmtzY2FwZTp6b29tPSIxMy44NTg3MTQiCiAgIGlua3NjYXBlOmN4PSI3NS40MTI5MDQiCiAgIGlua3NjYXBlOmN5PSIyMy4wNzc2MDYiCiAgIGlua3NjYXBlOndpbmRvdy14PSIwIgogICBpbmtzY2FwZTp3aW5kb3cteT0iMCIKICAgaW5rc2NhcGU6d2luZG93LW1heGltaXplZD0iMSIKICAgaW5rc2NhcGU6Y3VycmVudC1sYXllcj0iTGF5ZXJfMSIgLz4KPHN0eWxlCiAgIHR5cGU9InRleHQvY3NzIgogICBpZD0ic3R5bGUzNzY5Ij4KCS5zdDB7ZmlsbDojRTZFN0U4O30KCS5zdDF7ZmlsbDp1cmwoI1NWR0lEXzFfKTt9Cjwvc3R5bGU+Cgo8bGluZWFyR3JhZGllbnQKICAgaWQ9IlNWR0lEXzFfIgogICBncmFkaWVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSIKICAgeDE9IjI2LjcwMDAwMSIKICAgeTE9Ii05Ljg1MDE5OTciCiAgIHgyPSIyNi43MDAwMDEiCiAgIHkyPSI0My4xNjYiCiAgIGdyYWRpZW50VHJhbnNmb3JtPSJtYXRyaXgoMSwwLDAsLTEsMiw2MC4wMDAwMDIpIj4KCTxzdG9wCiAgIG9mZnNldD0iMCIKICAgc3R5bGU9InN0b3AtY29sb3I6I0ZGRjEwMCIKICAgaWQ9InN0b3AzNzczIiAvPgoJPHN0b3AKICAgb2Zmc2V0PSIxIgogICBzdHlsZT0ic3RvcC1jb2xvcjojRjA1QTI4IgogICBpZD0ic3RvcDM3NzUiIC8+CjwvbGluZWFyR3JhZGllbnQ+CjxwYXRoCiAgIGNsYXNzPSJzdDEiCiAgIGQ9Im0gNTUuMSwyNS41MDAwMDIgYyAtMC4xLC0xIC0wLjMsLTIuMSAtMC42LC0zLjMgLTAuMywtMS4yIC0wLjgsLTIuNiAtMS41LC00IC0wLjcsLTEuNCAtMS42LC0yLjkgLTIuOCwtNC4zIC0wLjUsLTAuNiAtMSwtMS4xIC0xLjUsLTEuNiAwLjgsLTMuMjAwMDAwNCAtMSwtNi4wMDAwMDA0IC0xLC02LjAwMDAwMDQgLTMuMSwtMC4yIC01LjEsMSAtNS44LDEuNSAtMC4xLC0wLjEgLTAuMiwtMC4xIC0wLjQsLTAuMiAtMC41LC0wLjIgLTEsLTAuNCAtMS42LC0wLjYgLTAuNiwtMC4yIC0xLjEsLTAuMyAtMS43LC0wLjUgLTAuNiwtMC4xIC0xLjIsLTAuMyAtMS44LC0wLjMgLTAuMSwwIC0wLjIsMCAtMC4zLDAgQyAzNC44LDEuODAwMDAxNiAzMC45LDEuNTI1ODc4OWUtNiAzMC45LDEuNTI1ODc4OWUtNiAyNi42LDIuODAwMDAxNiAyNS43LDYuNjAwMDAxNiAyNS43LDYuNjAwMDAxNiBjIDAsMCAwLDAuMSAwLDAuMiAtMC4yLDAuMSAtMC41LDAuMSAtMC43LDAuMiAtMC4zLDAuMSAtMC43LDAuMiAtMSwwLjMgLTAuMywwLjEgLTAuNywwLjMgLTEsMC40IC0wLjcsMC4zIC0xLjMsMC42IC0xLjksMSAtMC42LDAuMyAtMS4yLDAuNyAtMS44LDEuMSAtMC4xLDAgLTAuMiwtMC4xIC0wLjIsLTAuMSAtNiwtMi4zIC0xMS40LDAuNTAwMDAwNCAtMTEuNCwwLjUwMDAwMDQgLTAuNSw2LjQgMi40LDEwLjQgMywxMS4yIC0wLjEsMC40IC0wLjMsMC44IC0wLjQsMS4yIC0wLjQsMS40IC0wLjgsMi45IC0xLDQuNSAwLDAuMiAtMC4xLDAuNCAtMC4xLDAuNyAtNS42LDIuNyAtNy4yLDguNCAtNy4yLDguNCA0LjYsNS4zIDEwLDUuNyAxMCw1LjcgdiAwIGMgMC43LDEuMiAxLjUsMi40IDIuNCwzLjUgMC40LDAuNSAwLjgsMC45IDEuMiwxLjMgLTEuNyw0LjggMC4yLDguOSAwLjIsOC45IDUuMiwwLjIgOC42LC0yLjMgOS4zLC0yLjggMC41LDAuMiAxLDAuMyAxLjYsMC41IDEuNiwwLjQgMy4yLDAuNiA0LjgsMC43IDAuNCwwIDAuOCwwIDEuMiwwIGggMC4yIDAuMSAwLjMgMC4zIHYgMCBjIDIuNCwzLjUgNi43LDQgNi43LDQgMy40LC0zLjYgMy4yLC03LjIgMy4yLC03LjIgbCAtMC4xLC0wLjEgYyAwLjcsLTAuNSAxLjMsLTEgMS45LC0xLjUgMS4yLC0xLjEgMi4zLC0yLjQgMy4yLC0zLjcgMC4xLC0wLjEgMC4yLC0wLjMgMC4yLC0wLjQgMy40LDAuMiA1LjksLTIuMSA1LjksLTIuMSAtMC42LC00IC0zLjEsLTUuNyAtMy4xLC01LjcgaCAtMC4xIGMgMCwtMC4yIDAsLTAuNSAwLjEsLTAuNyAwLC0wLjQgMCwtMC44IDAsLTEuMiB2IC0wLjMgLTAuMSAtMC4xIGMgMCwtMC4xIDAsLTAuMSAwLC0wLjEgdiAtMC4yIC0wLjMgYyAwLC0wLjEgMCwtMC4yIDAsLTAuMyAwLC0wLjEgMCwtMC4yIDAsLTAuMyB2IC0wLjMgLTAuMyBjIC0wLjEsLTAuNCAtMC4xLC0wLjggLTAuMiwtMS4yIC0wLjQsLTEuNSAtMSwtMyAtMS44LC00LjMgLTAuOCwtMS4zIC0xLjgsLTIuNSAtMi45LC0zLjUgLTEuMSwtMSAtMi40LC0xLjggLTMuNywtMi40IC0xLjMsLTAuNiAtMi43LC0xIC00LjEsLTEuMSAtMC43LC0wLjEgLTEuNCwtMC4xIC0yLC0wLjEgaCAtMC4zIC0wLjEgLTAuMSAtMC4xIC0wLjMgYyAtMC4xLDAgLTAuMiwwIC0wLjMsMCAtMC4zLDAgLTAuNywwLjEgLTEsMC4xIC0xLjQsMC4zIC0yLjcsMC43IC0zLjgsMS40IC0xLjEsMC43IC0yLjEsMS41IC0yLjksMi41IC0wLjgsMSAtMS40LDIgLTEuOSwzLjEgLTAuNCwxLjEgLTAuNywyLjIgLTAuNywzLjMgMCwwLjMgMCwwLjYgMCwwLjggMCwwLjEgMCwwLjEgMCwwLjIgdiAwLjIgYyAwLDAuMSAwLDAuMyAwLDAuNCAwLjEsMC42IDAuMiwxLjEgMC4zLDEuNiAwLjMsMSAwLjgsMiAxLjQsMi44IDAuNiwwLjggMS4zLDEuNSAyLjEsMiAwLjgsMC41IDEuNiwwLjkgMi40LDEuMSAwLjgsMC4yIDEuNiwwLjMgMi4zLDAuMyAwLjEsMCAwLjIsMCAwLjMsMCBoIDAuMSAwLjEgYyAwLjEsMCAwLjIsMCAwLjIsMCAwLDAgMCwwIDAuMSwwIGggMC4xIDAuMSBjIDAuMSwwIDAuMiwwIDAuMywwIDAuMSwwIDAuMiwwIDAuMywtMC4xIDAuMiwwIDAuMywtMC4xIDAuNSwtMC4xIDAuMywtMC4xIDAuNiwtMC4yIDAuOSwtMC40IDAuMywtMC4xIDAuNSwtMC4zIDAuOCwtMC41IDAuMSwtMC4xIDAuMSwtMC4xIDAuMiwtMC4yIDAuMywtMC4yIDAuMywtMC42IDAuMSwtMC44IC0wLjIsLTAuMiAtMC41LC0wLjMgLTAuNywtMC4xIC0wLjIsLTAuMiAtMC4yLC0wLjEgLTAuMywtMC4xIC0wLjIsMC4xIC0wLjQsMC4yIC0wLjcsMC4zIC0wLjIsMC4xIC0wLjUsMC4xIC0wLjgsMC4yIC0wLjEsMCAtMC4zLDAgLTAuNCwwIC0wLjEsMCAtMC4xLDAgLTAuMiwwIC0wLjEsMCAtMC4xLDAgLTAuMiwwIC0wLjEsMCAtMC4xLDAgLTAuMiwwIC0wLjEsMCAtMC4yLDAgLTAuMiwwIHYgMCAwIEggMzQuMSAzNCBjIC0wLjEsMCAtMC4xLDAgLTAuMiwwIC0wLjYsLTAuMSAtMS4yLC0wLjMgLTEuNywtMC41IC0wLjYsLTAuMyAtMS4xLC0wLjYgLTEuNiwtMS4xIC0wLjUsLTAuNCAtMC45LC0xIC0xLjMsLTEuNiAtMC4zLC0wLjYgLTAuNiwtMS4zIC0wLjcsLTIgLTAuMSwtMC4zIC0wLjEsLTAuNyAtMC4xLC0xLjEgMCwtMC4xIDAsLTAuMiAwLC0wLjMgdiAwIDAgLTAuMSAtMC4xIGMgMCwtMC4yIDAsLTAuNCAwLjEsLTAuNiAwLjMsLTEuNSAxLC0zIDIuMiwtNC4yIDAuMywtMC4zIDAuNiwtMC41IDEsLTAuOCAwLjMsLTAuMiAwLjcsLTAuNCAxLjEsLTAuNiAwLjQsLTAuMiAwLjgsLTAuMyAxLjIsLTAuNCAwLjQsLTAuMSAwLjgsLTAuMiAxLjIsLTAuMiAwLjIsMCAwLjQsMCAwLjYsMCAwLjEsMCAwLjEsMCAwLjEsMCBoIDAuMiAwLjEgdiAwIDAgaCAwLjIgYyAwLjUsMCAwLjksMC4xIDEuNCwwLjIgMC45LDAuMiAxLjgsMC41IDIuNiwxIDEuNiwwLjkgMywyLjMgMy45LDQgMC40LDAuOCAwLjcsMS44IDAuOSwyLjcgMCwwLjIgMC4xLDAuNSAwLjEsMC43IHYgMC4yIDAuMiBjIDAsMC4xIDAsMC4xIDAsMC4yIDAsMC4xIDAsMC4xIDAsMC4yIHYgMC4yIDAuMiBjIDAsMC4xIDAsMC4zIDAsMC40IDAsMC4zIDAsMC41IC0wLjEsMC44IDAsMC4zIC0wLjEsMC41IC0wLjEsMC44IC0wLjEsMC4xIC0wLjEsMC4zIC0wLjIsMC42IC0wLjEsMC41IC0wLjMsMSAtMC41LDEuNSAtMC40LDEgLTAuOSwxLjkgLTEuNSwyLjcgLTEuMiwxLjcgLTIuOSwzLjEgLTQuOCwzLjkgLTEsMC40IC0yLDAuNyAtMywwLjkgLTAuNSwwLjEgLTEsMC4xIC0xLjYsMC4yIGggLTAuMSAtMC4xIC0wLjIgLTAuMyAtMC4xIGMgMC4xLDAgMCwwIDAsMCBoIC0wLjEgYyAtMC4zLDAgLTAuNiwwIC0wLjgsMCAtMS4xLC0wLjEgLTIuMiwtMC4zIC0zLjMsLTAuNiAtMS4xLC0wLjMgLTIuMSwtMC43IC0zLjEsLTEuMiAtMiwtMSAtMy43LC0yLjUgLTUuMSwtNC4yIC0wLjcsLTAuOSAtMS4zLC0xLjggLTEuOCwtMi44IC0wLjUsLTEgLTAuOSwtMiAtMS4yLC0zIC0wLjMsLTEgLTAuNSwtMi4xIC0wLjUsLTMuMiB2IC0wLjIgLTAuMSAwIC0wLjEgLTAuMiAwIC0wLjEgLTAuMSAtMC4zIDAgMCAtMC4xIGMgMCwtMC4xIDAsLTAuMyAwLC0wLjQgMCwtMC41IDAuMSwtMS4xIDAuMSwtMS42IDAuMSwtMC41IDAuMiwtMS4xIDAuMywtMS42IDAuMSwtMC41IDAuMiwtMS4xIDAuNCwtMS42IDAuMywtMS4xIDAuNywtMi4xIDEuMSwtMy4xIDAuOSwtMiAyLjEsLTMuNyAzLjUsLTUuMSAwLjQsLTAuMyAwLjcsLTAuNyAxLjEsLTEgMC40LC0wLjMgMC44LC0wLjYgMS4yLC0wLjkgMC40LC0wLjMgMC44LC0wLjUgMS4zLC0wLjcgMC4yLC0wLjEgMC40LC0wLjIgMC43LC0wLjMgMC4xLDAgMC4yLC0wLjEgMC4zLC0wLjEgMC4xLC0wLjEgMC4yLC0wLjEgMC4zLC0wLjEgMC40LC0wLjIgMC45LC0wLjQgMS40LC0wLjUgMC4xLDAgMC4yLC0wLjEgMC40LC0wLjEgMC4xLDAgMC4yLC0wLjEgMC40LC0wLjEgMC4yLC0wLjEgMC41LC0wLjEgMC43LC0wLjIgMC4xLDAgMC4yLC0wLjEgMC40LC0wLjEgMC4xLDAgMC4yLC0wLjEgMC40LC0wLjEgMC4xLDAgMC4yLDAgMC40LC0wLjEgaCAwLjIgMC4yIGMgMC4xLDAgMC4yLDAgMC40LC0wLjEgMC4xLDAgMC4zLDAgMC40LC0wLjEgMC4xLDAgMC4zLDAgMC40LDAgMC4xLDAgMC4yLDAgMC4zLDAgaCAwLjIgMC4xIDAuMSBjIDAuMSwwIDAuMywwIDAuNCwwIGggMC4yIGMgMCwwIDAuMSwwIDAsMCB2IDAgaCAwLjEgYyAwLjEsMCAwLjIsMCAwLjQsMCAwLjUsMCAwLjksMCAxLjQsMCAwLjksMCAxLjgsMC4xIDIuNywwLjMgMS44LDAuMyAzLjQsMC45IDQuOSwxLjYgMS41LDAuNyAyLjksMS42IDQsMi42IDAuMSwwLjEgMC4xLDAuMSAwLjIsMC4yIDAuMSwwLjEgMC4xLDAuMSAwLjIsMC4yIDAuMSwwLjEgMC4zLDAuMyAwLjQsMC40IDAuMSwwLjEgMC4zLDAuMyAwLjQsMC40IDAuMSwwLjEgMC4zLDAuMyAwLjQsMC40IDAuNSwwLjUgMSwxLjEgMS40LDEuNiAwLjgsMS4xIDEuNSwyLjEgMiwzLjIgMCwwLjEgMC4xLDAuMSAwLjEsMC4yIDAsMC4xIDAuMSwwLjEgMC4xLDAuMiAwLjEsMC4xIDAuMSwwLjMgMC4yLDAuNCAwLjEsMC4xIDAuMSwwLjIgMC4yLDAuNCAwLjEsMC4xIDAuMSwwLjIgMC4yLDAuNCAwLjIsMC41IDAuNCwwLjkgMC41LDEuNCAwLjIsMC43IDAuNCwxLjMgMC42LDEuOSAwLjEsMC4yIDAuMywwLjQgMC41LDAuMyAwLjIsMCAwLjQsLTAuMiAwLjQsLTAuNCAtMC4yLC0xLjEgLTAuMiwtMS44IC0wLjMsLTIuNiB6IgogICBpZD0icGF0aDM3NzgiCiAgIGlua3NjYXBlOmNvbm5lY3Rvci1jdXJ2YXR1cmU9IjAiCiAgIHN0eWxlPSJmaWxsOnVybCgjU1ZHSURfMV8pIiAvPgo8L3N2Zz4=
+      mediatype: image/svg+xml
+  install:
+    spec:
+      deployments:
+        - name: grafana-operator
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                name: grafana-operator
+            strategy: { }
+            template:
+              metadata:
+                labels:
+                  name: grafana-operator
+              spec:
+                containers:
+                  - args:
+                    command:
+                      - grafana-operator
+                    env:
+                      - name: TEMPLATE_PATH
+                        value: /usr/local/bin/templates
+                      - name: WATCH_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                      - name: OPERATOR_NAME
+                        value: grafana-operator
+                    image: quay.io/integreatly/grafana-operator:v3.10.1
+                    imagePullPolicy: Always
+                    name: grafana-operator
+                    ports:
+                      - containerPort: 60000
+                        name: metrics
+                    resources: { }
+                serviceAccountName: grafana-operator
+      permissions:
+        - rules:
+            - apiGroups:
+                - ''
+              resources:
+                - pods
+                - services
+                - endpoints
+                - persistentvolumeclaims
+                - events
+                - configmaps
+                - secrets
+                - serviceaccounts
+              verbs:
+                - '*'
+            - apiGroups:
+                - apps
+              resources:
+                - deployments
+                - deployments/finalizers
+                - daemonsets
+                - replicasets
+                - statefulsets
+              verbs:
+                - '*'
+            - apiGroups:
+                - route.openshift.io
+              resources:
+                - routes
+                - routes/custom-host
+              verbs:
+                - '*'
+            - apiGroups:
+                - monitoring.coreos.com
+              resources:
+                - servicemonitors
+              verbs:
+                - get
+                - create
+            - apiGroups:
+                - extensions
+              resources:
+                - ingresses
+              verbs:
+                - '*'
+            - apiGroups:
+                - integreatly.org
+              resources:
+                - grafanas
+                - grafanadashboards
+                - grafanadatasources
+                - grafanas/finalizers
+                - grafanas/status
+                - grafanadashboards/status
+                - grafanadatasources/status
+              verbs:
+                - '*'
+          serviceAccountName: grafana-operator
+    strategy: deployment
+  installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: false
+      type: AllNamespaces
+  keywords:
+    - Grafana
+    - Metrics
+    - Monitoring
+  links:
+    - name: Documentation
+      url: https://github.com/integr8ly/grafana-operator/tree/v3.10.0/documentation
+    - name: Grafana
+      url: https://grafana.com
+  maintainers:
+    - email: integreatly-dev@redhat.com
+      name: Red Hat
+  maturity: alpha
+  provider:
+    name: Red Hat
+  replaces: grafana-operator.v3.10.0
+  version: 3.10.1
+
+

--- a/deploy/olm-catalog/grafana-operator/3.x.x/3.10.1/grafanadashboards.integreatly.org.crd.yaml
+++ b/deploy/olm-catalog/grafana-operator/3.x.x/3.10.1/grafanadashboards.integreatly.org.crd.yaml
@@ -1,0 +1,43 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: grafanadashboards.integreatly.org
+spec:
+  group: integreatly.org
+  names:
+    kind: GrafanaDashboard
+    listKind: GrafanaDashboardList
+    plural: grafanadashboards
+    singular: grafanadashboard
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha1
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            name:
+              type: string
+            json:
+              type: string
+            jsonnet:
+              description: Jsonnet source. Has access to grafonnet.
+              type: string
+            url:
+              type: string
+              description: URL to dashboard json
+            datasources:
+              type: array
+              items:
+                description: Input datasources to resolve before importing
+                type: object
+            plugins:
+              type: array
+              items:
+                description: Grafana Plugin Object
+                type: object
+            customFolderName:
+              description: Folder name that this dashboard will be assigned to.
+              type: string

--- a/deploy/olm-catalog/grafana-operator/3.x.x/3.10.1/grafanadatasources.integreatly.org.crd.yaml
+++ b/deploy/olm-catalog/grafana-operator/3.x.x/3.10.1/grafanadatasources.integreatly.org.crd.yaml
@@ -1,0 +1,35 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: grafanadatasources.integreatly.org
+spec:
+  group: integreatly.org
+  names:
+    kind: GrafanaDataSource
+    listKind: GrafanaDataSourceList
+    plural: grafanadatasources
+    singular: grafanadatasource
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha1
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          required: ["datasources", "name"]
+          properties:
+            name:
+              type: string
+              minimum: 1
+            datasources:
+              type: array
+              items:
+                description: Grafana Datasource Object
+                type: object

--- a/deploy/olm-catalog/grafana-operator/3.x.x/3.10.1/grafanas.integreatly.org.crd.yaml
+++ b/deploy/olm-catalog/grafana-operator/3.x.x/3.10.1/grafanas.integreatly.org.crd.yaml
@@ -1,0 +1,237 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: grafanas.integreatly.org
+spec:
+  group: integreatly.org
+  names:
+    kind: Grafana
+    listKind: GrafanaList
+    plural: grafanas
+    singular: grafana
+  scope: Namespaced
+  subresources:
+    status: { }
+  version: v1alpha1
+  validation:
+    openAPIV3Schema:
+      required: [ "spec" ]
+      properties:
+        spec:
+          properties:
+            containers:
+              type: array
+              items:
+                type: object
+                description: Additional container to add to the grafana pod
+            secrets:
+              type: array
+              items:
+                type: string
+                description: Secret to be mounted as volume into the grafana deployment
+            configMaps:
+              type: array
+              items:
+                type: string
+                description: Config map to be mounted as volume into the grafana deployment
+            logLevel:
+              type: string
+              description: Log level of the grafana instance, defaults to info
+            adminUser:
+              type: string
+              description: Default admin user name
+            adminPassword:
+              type: string
+              description: Default admin password
+            basicAuth:
+              type: boolean
+              description: Basic auth enabled
+            disableLoginForm:
+              type: boolean
+              description: Disable login form
+            disableSignoutMenu:
+              type: boolean
+              description: Disable signout menu
+            anonymous:
+              type: boolean
+              description: Anonymous auth enabled
+            config:
+              type: object
+              description: Grafana config
+            ingress:
+              type: object
+              properties:
+                enabled:
+                  type: boolean
+                  description: Create an ingress / route
+                ingressClassName:
+                  type: string
+                  description: Ingress class name
+                path:
+                  type: string
+                  description: Ingress path
+                pathType:
+                  type: string
+                  description: pathType specifies how ingress paths should be matched
+                hostname:
+                  type: string
+                  description: The hostname of the ingress / route
+                annotations:
+                  type: object
+                  description: Additional annotations for the ingress / route
+                labels:
+                  type: object
+                  description: Additional labels for the ingress / route
+                targetPort:
+                  type: string
+                  description: Override port to target in the grafana service
+            service:
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: Override default service name
+                ports:
+                  type: array
+                  description: Override default ports
+                  items:
+                    type: object
+                    description: A port to add to the grafana service
+                annotations:
+                  type: object
+                  description: Additional annotations for the service
+                labels:
+                  type: object
+                  description: Additional labels for the service
+                type:
+                  type: string
+                  description: Service type (NodePort, ClusterIP or LoadBalancer)
+            deployment:
+              type: object
+              properties:
+                annotations:
+                  type: object
+                  description: Additional annotations for the service
+                labels:
+                  type: object
+                  description: Additional labels for the service
+                nodeSelector:
+                  type: object
+                  description: Additional labels for the running grafana pods in a labeled node.
+                tolerations:
+                  type: array
+                  description: Additonal labels for running grafana pods in tained nodes.
+                affinity:
+                  type: object
+                  description: Additonal labels for running grafana pods with affinity properties.
+                envFrom:
+                  type: array
+                  description: Environment variables from Secret or ConfigMap.
+                skipCreateAdminAccount:
+                  type: boolean
+                  description: Disable creating a random admin user
+                priorityClassName:
+                  type: string
+                  description: Pod priority class name
+
+            serviceAccount:
+              type: object
+              properties:
+                skip:
+                  type: boolean
+                  description: Disable ServiceAccount creation for grafana
+                annotations:
+                  type: object
+                  description: Additional annotations for the serviceaccount
+                labels:
+                  type: object
+                  description: Additional labels for the serviceaccount
+            client:
+              type: object
+              description: Grafana client settings
+            compat:
+              type: object
+              description: Backwards compatibility switches
+            dashboardLabelSelectors:
+              type: array
+              items:
+                type: object
+                description: Label selector or match expressions
+            jsonnet:
+              type: object
+              description: Jsonnet library configuration
+            livenessProbeSpec:
+              type: object
+              properties:
+                initialDelaySeconds:
+                  description: >-
+                    Number of seconds after the container has
+                    started before liveness probes are initiated. More info:
+                    https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                  format: int32
+                  type: integer
+                timeoutSeconds:
+                  description: Number of seconds after which the probe times out. Defaults to 1 second.
+                    Minimum value is 1.
+                  format: int32
+                  type: integer
+                periodSeconds:
+                  description: >-
+                    How often (in seconds) to perform the probe.
+                    Default to 10 seconds. Minimum value is 1.
+                  format: int32
+                  type: integer
+                successThreshold:
+                  description: >-
+                    Minimum consecutive successes for the probe
+                    to be considered successful after having failed. Defaults
+                    to 1. Must be 1 for liveness and startup. Minimum value
+                    is 1.
+                  format: int32
+                  type: integer
+                failureThreshold:
+                  description: >-
+                    When a probe fails, Kubernetes will try failureThreshold times before giving up.
+                    Giving up in case of liveness probe means restarting the container.
+                    In case of readiness probe the Pod will be marked Unready.
+                    Defaults to 3. Minimum value is 1.
+                  format: int32
+                  type: integer
+            readinessProbeSpec:
+              type: object
+              properties:
+                initialDelaySeconds:
+                  description: >-
+                    Number of seconds after the container has
+                    started before liveness probes are initiated. More info
+                    https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                  format: int32
+                  type: integer
+                timeoutSeconds:
+                  description: >-
+                    Number of seconds after which the probe times out. Defaults to 1 second.
+                    Minimum value is 1.
+                  format: int32
+                  type: integer
+                periodSeconds:
+                  description: >-
+                    How often (in seconds) to perform the probe.
+                    Default to 10 seconds. Minimum value is 1.
+                  format: int32
+                  type: integer
+                successThreshold:
+                  description: >-
+                    Minimum consecutive successes for the probe
+                    to be considered successful after having failed. Defaults
+                    to 1. Must be 1 for liveness and startup. Minimum value
+                    is 1.
+                  format: int32
+                  type: integer
+                failureThreshold:
+                  description: >-
+                    When a probe fails, Kubernetes will try failureThreshold times before giving up.
+                    Giving up in case of liveness probe means restarting the container.
+                    In case of readiness probe the Pod will be marked Unready.
+                    Defaults to 3. Minimum value is 1.
+                  format: int32
+                  type: integer

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -17,7 +17,7 @@ spec:
       serviceAccountName: grafana-operator
       containers:
         - name: grafana-operator
-          image: quay.io/integreatly/grafana-operator:v3.10.0
+          image: quay.io/integreatly/grafana-operator:v3.10.1
           ports:
             - containerPort: 60000
               name: metrics

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 var (
-	Version = "3.10.0"
+	Version = "3.10.1"
 )


### PR DESCRIPTION
## Description
bump to version 3.10.1 to pick up newer base image with CVE fix
See https://issues.redhat.com/browse/MGDAPI-1715

## Relevant issues/tickets
https://issues.redhat.com/browse/MGDAPI-1715

## Type of change

## Verification steps
Run the operator locally and verify working as expected
