### PR TITLE
provide additional error context during failures

### DIFF
--- a/pkg/controller/grafanadashboard/grafana_client.go
+++ b/pkg/controller/grafanadashboard/grafana_client.go
@@ -179,15 +179,17 @@ func (r *GrafanaClientImpl) CreateOrUpdateFolder(folderInputName string) (Grafan
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != 200 {
-		return response, fmt.Errorf(
-			"error creating folder, expected status 200 but got %v",
-			resp.StatusCode)
-	}
-
 	data, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return response, err
+	}
+
+	if resp.StatusCode != 200 {
+		return response, fmt.Errorf(
+			"error creating folder, expected status 200 but got %v: %s",
+			resp.StatusCode,
+			data,
+		)
 	}
 
 	err = json.Unmarshal(data, &response)
@@ -236,15 +238,17 @@ func (r *GrafanaClientImpl) CreateOrUpdateDashboard(dashboard []byte, folderID i
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != 200 {
-		return response, fmt.Errorf(
-			"error creating dashboard, expected status 200 but got %v",
-			resp.StatusCode)
-	}
-
 	data, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return response, err
+	}
+
+	if resp.StatusCode != 200 {
+		return response, fmt.Errorf(
+			"error creating dashboard, expected status 200 but got %v: %s",
+			resp.StatusCode,
+			data,
+		)
 	}
 
 	err = json.Unmarshal(data, &response)


### PR DESCRIPTION
Before:
```
{"msg": "cannot submit dashboard monitoring/gitlab-projects","error":"error creating dashboard, expected status 200 but got 400"}"
```

After:
```
{"msg": "cannot submit dashboard monitoring/gitlab-projects","error":"error creating dashboard, expected status 200 but got 400: {\"message\":\"Dashboard title cannot be empty\"}"
```

## Description
Debugging a 400 error recently while migrating from grafonnet to grafonnet-7.0. There's not a migration guide at the moment, so I've been playing whack-a-mole updating things. Eventually got to a point where my jsonnet was rendering but the dash was 4xx'ing.

Adding this little bit of logging was clutch in making me realize I had to provide a dashboard title in my `grafana.dashboard.new` call.

## Relevant issues/tickets
* https://github.com/integr8ly/grafana-operator/issues/370: Similar issue. Lots of debug diving required.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
<!-- Tick options that apply, in-code tests are not required but please provide test cases and list steps in "verification steps" with the steps you used to verify this -->
- [ ] This change requires a documentation update 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer

## Verification steps
* I can produce the grafanadashboard CRD that produces this error. This is strictly a logging change.

## Possible Risks / Improvements
* `data` may be long. This does get pushed into kube events and _may_ come up against character limits depending on what the upstream grafana API decides to put in the payload. 
* Ostensibly, the grafana API has a spec for their error format and we could do a more robust job parsing things. Because I didn't invest time into decoding their spec, I simply dump the body and assume it's a string. Though not as ergonomic, this should be fairly foolproof. I believe this to be reasonably safe because we're interacting with a restful API.
* We're already doing an ioutil.ReadAll (regardless of the ordering) in the existing operator so if this was a source of memory consumption / pain due to large payloads, we'd already be feeling it.
