### PR TITLE
fix: add watch namespace back to mgr

### DIFF
--- a/main.go
+++ b/main.go
@@ -110,8 +110,15 @@ func main() {
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
+	namespace, err := k8sutil.GetWatchNamespace()
+	if err != nil {
+		log.Log.Error(err, "failed to get watch namespace")
+		os.Exit(1)
+	}
+
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,
+		Namespace:              namespace,
 		MetricsBindAddress:     metricsAddr,
 		Port:                   9443,
 		HealthProbeBindAddress: probeAddr,
@@ -120,11 +127,6 @@ func main() {
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
-		os.Exit(1)
-	}
-	namespace, err := k8sutil.GetWatchNamespace()
-	if err != nil {
-		log.Log.Error(err, "failed to get watch namespace")
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
## Description

The operator was not constraining the Grafana controller to the operator namespace.



## Type of change

Set the namespace when creating the controller manager in main.go.


## Verification steps

* Deploy the operator using operator.yaml, but make sure to point to an image created from master
* Make sure that Grafana CRs in other namespaces are not discovered
* Make sure that Grafana CRs in the operators namespace are discovered
