### PR TITLE
fix: use default storage class when class is not defined

### DIFF
--- a/pkg/controller/model/grafanaDataPvc.go
+++ b/pkg/controller/model/grafanaDataPvc.go
@@ -23,6 +23,14 @@ func getPVCAnnotations(cr *v1alpha1.Grafana, existing map[string]string) map[str
 	return MergeAnnotations(cr.Spec.DataStorage.Annotations, existing)
 }
 
+func getStorageClass(cr *v1alpha1.Grafana) *string {
+	if cr.Spec.DataStorage.Class == "" {
+		return nil
+	}
+
+	return &cr.Spec.DataStorage.Class
+}
+
 func getPVCSpec(cr *v1alpha1.Grafana) corev1.PersistentVolumeClaimSpec {
 	return corev1.PersistentVolumeClaimSpec{
 		AccessModes: cr.Spec.DataStorage.AccessModes,
@@ -31,7 +39,7 @@ func getPVCSpec(cr *v1alpha1.Grafana) corev1.PersistentVolumeClaimSpec {
 				corev1.ResourceStorage: cr.Spec.DataStorage.Size,
 			},
 		},
-		StorageClassName: &cr.Spec.DataStorage.Class,
+		StorageClassName: getStorageClass(cr),
 	}
 }
 


### PR DESCRIPTION
Thank you for your great works! I fixed some behavior.

## Description
use default storage class when class is not defined

## Relevant issues/tickets
<!-- Please include a link to the issue or ticket that applies to this pull request, delete this heading if not relevant -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
<!-- Tick options that apply, in-code tests are not required but please provide test cases and list steps in "verification steps" with the steps you used to verify this -->
- [ ] This change requires a documentation update 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [x] Verified independently on a cluster by reviewer

## Verification steps

When Grafana.spec.dataStorage.class is not defined or set nil, generated PVC.spec.storageClassName is set "".
But I think we prefer to use default storageClass.


```yaml
apiVersion: integreatly.org/v1alpha1
kind: Grafana
metadata:
  name: grafana
spec:
  baseImage: grafana/grafana:7.4.3
  ...
  dataStorage:
    accessModes:
    - ReadWriteOnce
    size: 5Gi
#    class: null
```

* default bahavior

```yaml
$ k -n grafana get pvc grafana-pvc -oyaml | k neat
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: grafana-pvc
  namespace: grafana
spec:
  accessModes:
  - ReadWriteOnce
  resources:
    requests:
      storage: 5Gi
  storageClassName: ""
```

* newer bahavior

```yaml
$ k -n grafana get pvc grafana-pvc -oyaml | k neat
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: grafana-pvc
  namespace: grafana
spec:
  accessModes:
  - ReadWriteOnce
  resources:
    requests:
      storage: 5Gi
  storageClassName: my-default-storageclass
```
